### PR TITLE
fix: base64 encode public key when adding auth

### DIFF
--- a/x/identifier/client/cli/tx.go
+++ b/x/identifier/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -59,7 +60,7 @@ func NewCreateIdentifierCmd() *cobra.Command {
 				id+"#keys-1",
 				"sepk256",
 				accAddrBech32,
-				string(pubKey.Bytes()),
+				base64.StdEncoding.EncodeToString(pubKey.Bytes()),
 			)
 
 			msg := types.NewMsgCreateIdentifier(


### PR DESCRIPTION
### Description

Fixes issue with public key encoding

### How to test

- `make init-dev`
- `make start-dev`

In another terminal

- `go run main.go tx identifier create-identifier --from validator --chain-id cash -y`
- `go run main.go tx identifier add-authentication `id of did` `pubKey` --from validator --chain-id cash -y`

