### PR TITLE
feat(did): remove auth from did document

### DIFF
--- a/proto/identifier/query.proto
+++ b/proto/identifier/query.proto
@@ -15,7 +15,10 @@ option go_package = "github.com/allinbits/cosmos-cash/x/identifier/types";
 service Query {
   	// Identifers queries all validators that match the given status.
   rpc Identifiers(QueryIdentifiersRequest) returns (QueryIdentifiersResponse) {
-    option (google.api.http).get = "/allinbits/identity/identitys";
+    option (google.api.http).get = "/allinbits/identifier/identifiers";
+  }
+  rpc Identifier(QueryIdentifierRequest) returns (QueryIdentifierResponse) {
+    option (google.api.http).get = "/allinbits/identifier/identifiers/{id}";
   }
 }
 
@@ -37,4 +40,15 @@ message QueryIdentifiersResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
+// QueryIdentifersRequest is request type for Query/Identifers RPC method.
+message QueryIdentifierRequest {
+  // status enables to query for validators matching a given status.
+  string id = 1;
+}
+
+// QueryIdentifersResponse is response type for the Query/Identifers RPC method
+message QueryIdentifierResponse {
+  // validators contains all the queried validators.
+  DidDocument didDocument = 1  [(gogoproto.nullable) = false];
+}
 // this line is used by starport scaffolding # 3

--- a/proto/identifier/tx.proto
+++ b/proto/identifier/tx.proto
@@ -12,6 +12,7 @@ service Msg {
   rpc CreateIdentifier(MsgCreateIdentifier) returns (MsgCreateIdentifierResponse);
   rpc AddAuthentication(MsgAddAuthentication) returns (MsgAddAuthenticationResponse);
   rpc AddService(MsgAddService) returns (MsgAddServiceResponse);
+  rpc DeleteAuthentication(MsgDeleteAuthentication) returns (MsgDeleteAuthenticationResponse);
 }
 
 // MsgCreateIdentifier defines a SDK message for creating a new identifer.
@@ -63,3 +64,16 @@ message MsgAddService {
 }
 
 message MsgAddServiceResponse {}
+
+message MsgDeleteAuthentication {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string     id             = 1; 
+  
+  string     key = 2;
+  // owner is the address of the user creating the message 
+  string owner = 3;
+}
+
+message MsgDeleteAuthenticationResponse {}

--- a/scripts/seeds/01_identifier_seeds.sh
+++ b/scripts/seeds/01_identifier_seeds.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 
+echo "Creating decentralized identifier for user: validator"
 cosmos-cashd tx identifier create-identifier --from validator --chain-id cash -y
 
+echo "Creating key for user auth2"
 echo 'y' | cosmos-cashd keys add auth2
 
+echo "Adding authentication to decentralized identifier for user: validator"
 cosmos-cashd tx identifier add-authentication did:cash:$(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show auth2 -p) --from validator --chain-id cash -y
 
+echo "Querying identifiers"
+cosmos-cashd query identifier identifiers --output json | jq
+
+echo "Adding service to decentralized identifier for user: validator"
 cosmos-cashd tx identifier add-service did:cash:$(cosmos-cashd keys show validator -a) new-verifiable-cred-3 KYCCredential cosmos-cash:new-verifiable-cred-3 --from validator --chain-id cash -y
+
+echo "Deleting authentication from decentralized identifier for user: validator"
+cosmos-cashd tx identifier delete-authentication did:cash:$(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show auth2 -p) --from validator --chain-id cash -y
+
+echo "Querying identifiers"
+cosmos-cashd query identifier identifiers --output json | jq

--- a/scripts/seeds/02_verifiable_credentials_seeds.sh
+++ b/scripts/seeds/02_verifiable_credentials_seeds.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+echo "Creating verifiable credential for user `validator`"
 cosmos-cashd tx verifiablecredentialservice create-verifiable-credential did:cash:$(cosmos-cashd keys show validator -a) --from validator --chain-id cash -y

--- a/x/identifier/client/cli/query.go
+++ b/x/identifier/client/cli/query.go
@@ -28,6 +28,7 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 	// this line is used by starport scaffolding # 1
 	cmd.AddCommand(
 		GetCmdQueryIdentifers(),
+		GetCmdQueryIdentifer(),
 	)
 
 	return cmd
@@ -54,6 +55,37 @@ func GetCmdQueryIdentifers() *cobra.Command {
 				&types.QueryIdentifiersRequest{
 					// Leaving status empty on purpose to query all validators.
 					Pagination: pageReq,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(result)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func GetCmdQueryIdentifer() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "identifier [id]",
+		Short: "Query for an identitifer",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			result, err := queryClient.Identifier(
+				context.Background(),
+				&types.QueryIdentifierRequest{
+					Id: args[0],
 				},
 			)
 			if err != nil {

--- a/x/identifier/client/cli/tx.go
+++ b/x/identifier/client/cli/tx.go
@@ -28,6 +28,7 @@ func GetTxCmd() *cobra.Command {
 		NewCreateIdentifierCmd(),
 		NewAddAuthenticationCmd(),
 		NewAddServiceCmd(),
+		NewDeleteAuthenticationCmd(),
 	)
 
 	return cmd
@@ -146,6 +147,38 @@ func NewAddServiceCmd() *cobra.Command {
 			msg := types.NewMsgAddService(
 				args[0],
 				&service,
+				accAddr.String(),
+			)
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func NewDeleteAuthenticationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete-authentication [id] [pubkey]",
+		Short:   "delete an authentication method from a decentralized identifier (did) document",
+		Example: fmt.Sprintf("delete an authentication method for a did document"),
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+			accAddr := clientCtx.GetFromAddress()
+
+			msg := types.NewMsgDeleteAuthentication(
+				args[0],
+				args[1],
 				accAddr.String(),
 			)
 

--- a/x/identifier/keeper/grpc_query.go
+++ b/x/identifier/keeper/grpc_query.go
@@ -29,3 +29,27 @@ func (q Keeper) Identifiers(
 		DidDocuments: identifiers,
 	}, nil
 }
+
+// Identifers implements the Identifers gRPC method
+func (q Keeper) Identifier(
+	c context.Context,
+	req *types.QueryIdentifierRequest,
+) (*types.QueryIdentifierResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "empty request")
+	}
+
+	if req.Id == "" {
+		return nil, status.Error(codes.InvalidArgument, "verifiable credential id cannot be empty")
+	}
+
+	ctx := sdk.UnwrapSDKContext(c)
+	identifier, found := q.GetIdentifier(ctx, []byte(req.Id))
+	if !found {
+		return nil, status.Error(codes.NotFound, "identifier not found: QueryIdentifier")
+	}
+
+	return &types.QueryIdentifierResponse{
+		identifier,
+	}, nil
+}

--- a/x/identifier/keeper/handler.go
+++ b/x/identifier/keeper/handler.go
@@ -25,6 +25,9 @@ func NewHandler(k Keeper) sdk.Handler {
 		case *types.MsgAddService:
 			res, err := msgServer.AddService(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+		case *types.MsgDeleteAuthentication:
+			res, err := msgServer.DeleteAuthentication(sdk.WrapSDKContext(ctx), msg)
+			return sdk.WrapServiceResult(ctx, res, err)
 		// this line is used by starport scaffolding # 1
 		default:
 			errMsg := fmt.Sprintf("unrecognized %s message type: %T", types.ModuleName, msg)

--- a/x/identifier/keeper/identifier.go
+++ b/x/identifier/keeper/identifier.go
@@ -44,6 +44,7 @@ func (k Keeper) GetAllIdentifiersWithCondition(
 ) (identifiers []types.DidDocument) {
 	val := k.GetAll(ctx, key, k.UnmarshalIdentifier)
 
+	// TODO: update to use iterator
 	for _, value := range val {
 		identifer := value.(types.DidDocument)
 		if identiferSelector(identifer) {

--- a/x/identifier/keeper/keeper.go
+++ b/x/identifier/keeper/keeper.go
@@ -35,13 +35,33 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 // Set sets a value in the db with a prefixed key
-func (k Keeper) Set(ctx sdk.Context, key []byte, prefix []byte, i interface{}, marshal MarshalFn) {
+func (k Keeper) Set(ctx sdk.Context,
+	key []byte,
+	prefix []byte,
+	i interface{},
+	marshal MarshalFn,
+) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(append(prefix, key...), marshal(i))
 }
 
+// Deletes a value form the sotre
+func (k Keeper) Delete(
+	ctx sdk.Context,
+	key []byte,
+	prefix []byte,
+) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(append(prefix, key...))
+}
+
 // Get gets an item from the store by bytes
-func (k Keeper) Get(ctx sdk.Context, key []byte, prefix []byte, unmarshal UnmarshalFn) (i interface{}, found bool) {
+func (k Keeper) Get(
+	ctx sdk.Context,
+	key []byte,
+	prefix []byte,
+	unmarshal UnmarshalFn,
+) (i interface{}, found bool) {
 	store := ctx.KVStore(k.storeKey)
 	value := store.Get(append(prefix, key...))
 
@@ -49,7 +69,11 @@ func (k Keeper) Get(ctx sdk.Context, key []byte, prefix []byte, unmarshal Unmars
 }
 
 // GetAll values from with a prefix from the store
-func (k Keeper) GetAll(ctx sdk.Context, prefix []byte, unmarshal UnmarshalFn) (i []interface{}) {
+func (k Keeper) GetAll(
+	ctx sdk.Context,
+	prefix []byte,
+	unmarshal UnmarshalFn,
+) (i []interface{}) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, prefix)
 	//TODO: return iterator and remove code below

--- a/x/identifier/types/codec.go
+++ b/x/identifier/types/codec.go
@@ -18,6 +18,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 		&MsgCreateIdentifier{},
 		&MsgAddAuthentication{},
 		&MsgAddService{},
+		&MsgDeleteAuthentication{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/identifier/types/msg.go
+++ b/x/identifier/types/msg.go
@@ -176,3 +176,60 @@ func (msg MsgAddService) GetSigners() []sdk.AccAddress {
 	}
 	return []sdk.AccAddress{accAddr}
 }
+
+// msg types
+const (
+	TypeMsgDeleteAuthentication = "delete-authentication"
+)
+
+var _ sdk.Msg = &MsgDeleteAuthentication{}
+
+// NewMsgDeleteAuthentication creates a new MsgDeleteAuthentication instance
+func NewMsgDeleteAuthentication(
+	id string,
+	key string,
+	owner string,
+) *MsgDeleteAuthentication {
+	return &MsgDeleteAuthentication{
+		Id:    id,
+		Key:   key,
+		Owner: owner,
+	}
+}
+
+// Route implements sdk.Msg
+func (MsgDeleteAuthentication) Route() string {
+	return RouterKey
+}
+
+// Type implements sdk.Msg
+func (MsgDeleteAuthentication) Type() string {
+	return TypeMsgDeleteAuthentication
+}
+
+// ValidateBasic performs a basic check of the MsgDeleteAuthentication fields.
+func (msg MsgDeleteAuthentication) ValidateBasic() error {
+	if msg.Id == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "empty id")
+	}
+
+	if msg.Key == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "authentication is required")
+	}
+
+	return nil
+
+}
+
+func (msg MsgDeleteAuthentication) GetSignBytes() []byte {
+	panic("IBC messages do not support amino")
+}
+
+// GetSigners implements sdk.Msg
+func (msg MsgDeleteAuthentication) GetSigners() []sdk.AccAddress {
+	accAddr, err := sdk.AccAddressFromBech32(msg.Owner)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{accAddr}
+}

--- a/x/identifier/types/query.pb.go
+++ b/x/identifier/types/query.pb.go
@@ -140,40 +140,138 @@ func (m *QueryIdentifiersResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
+// QueryIdentifersRequest is request type for Query/Identifers RPC method.
+type QueryIdentifierRequest struct {
+	// status enables to query for validators matching a given status.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+}
+
+func (m *QueryIdentifierRequest) Reset()         { *m = QueryIdentifierRequest{} }
+func (m *QueryIdentifierRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryIdentifierRequest) ProtoMessage()    {}
+func (*QueryIdentifierRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_5eda05580bf44a1c, []int{2}
+}
+func (m *QueryIdentifierRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryIdentifierRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryIdentifierRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryIdentifierRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryIdentifierRequest.Merge(m, src)
+}
+func (m *QueryIdentifierRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryIdentifierRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryIdentifierRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryIdentifierRequest proto.InternalMessageInfo
+
+func (m *QueryIdentifierRequest) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+// QueryIdentifersResponse is response type for the Query/Identifers RPC method
+type QueryIdentifierResponse struct {
+	// validators contains all the queried validators.
+	DidDocuments DidDocument `protobuf:"bytes,1,opt,name=didDocuments,proto3" json:"didDocuments"`
+}
+
+func (m *QueryIdentifierResponse) Reset()         { *m = QueryIdentifierResponse{} }
+func (m *QueryIdentifierResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryIdentifierResponse) ProtoMessage()    {}
+func (*QueryIdentifierResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_5eda05580bf44a1c, []int{3}
+}
+func (m *QueryIdentifierResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryIdentifierResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryIdentifierResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryIdentifierResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryIdentifierResponse.Merge(m, src)
+}
+func (m *QueryIdentifierResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryIdentifierResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryIdentifierResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryIdentifierResponse proto.InternalMessageInfo
+
+func (m *QueryIdentifierResponse) GetDidDocuments() DidDocument {
+	if m != nil {
+		return m.DidDocuments
+	}
+	return DidDocument{}
+}
+
 func init() {
 	proto.RegisterType((*QueryIdentifiersRequest)(nil), "allinbits.cosmoscash.identifier.QueryIdentifiersRequest")
 	proto.RegisterType((*QueryIdentifiersResponse)(nil), "allinbits.cosmoscash.identifier.QueryIdentifiersResponse")
+	proto.RegisterType((*QueryIdentifierRequest)(nil), "allinbits.cosmoscash.identifier.QueryIdentifierRequest")
+	proto.RegisterType((*QueryIdentifierResponse)(nil), "allinbits.cosmoscash.identifier.QueryIdentifierResponse")
 }
 
 func init() { proto.RegisterFile("identifier/query.proto", fileDescriptor_5eda05580bf44a1c) }
 
 var fileDescriptor_5eda05580bf44a1c = []byte{
-	// 392 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x92, 0xc1, 0x4a, 0xe3, 0x40,
-	0x1c, 0xc6, 0x33, 0xdd, 0xdd, 0xc2, 0x4e, 0xf7, 0x34, 0x2c, 0xdd, 0xd2, 0xd5, 0xb4, 0x14, 0xd4,
-	0x22, 0x3a, 0x43, 0xdb, 0x8b, 0x5e, 0x4b, 0x51, 0x3c, 0x08, 0x9a, 0x83, 0x07, 0x6f, 0x93, 0x74,
-	0x4c, 0x07, 0xda, 0x99, 0xb4, 0x33, 0x11, 0x73, 0xf5, 0x09, 0x04, 0x9f, 0xc2, 0xb3, 0x47, 0x5f,
-	0xa0, 0xc7, 0x82, 0x17, 0x4f, 0x22, 0xad, 0x0f, 0x22, 0xc9, 0x84, 0x26, 0xa2, 0x52, 0xf0, 0xf6,
-	0x25, 0xf3, 0x7d, 0xdf, 0xfc, 0xfe, 0xc3, 0x1f, 0x96, 0x79, 0x9f, 0x09, 0xcd, 0x2f, 0x38, 0x9b,
-	0x90, 0x71, 0xc8, 0x26, 0x11, 0x0e, 0x26, 0x52, 0x4b, 0x54, 0xa3, 0xc3, 0x21, 0x17, 0x2e, 0xd7,
-	0x0a, 0x7b, 0x52, 0x8d, 0xa4, 0xf2, 0xa8, 0x1a, 0xe0, 0xcc, 0x5c, 0x5d, 0xf3, 0xa5, 0xf4, 0x87,
-	0x8c, 0xd0, 0x80, 0x13, 0x2a, 0x84, 0xd4, 0x54, 0x73, 0x29, 0x94, 0x89, 0x57, 0xb7, 0x4d, 0x88,
-	0xb8, 0x54, 0x31, 0xd3, 0x4b, 0x2e, 0x5b, 0x2e, 0xd3, 0xb4, 0x45, 0x02, 0xea, 0x73, 0x91, 0x98,
-	0x53, 0xef, 0xff, 0x1c, 0x42, 0x26, 0xd3, 0xc3, 0xbf, 0xbe, 0xf4, 0x65, 0x22, 0x49, 0xac, 0xcc,
-	0xdf, 0x46, 0x04, 0xff, 0x9d, 0xc6, 0xa5, 0x47, 0x4b, 0xbb, 0x72, 0xd8, 0x38, 0x64, 0x4a, 0xa3,
-	0x32, 0x2c, 0x2a, 0x4d, 0x75, 0xa8, 0x2a, 0xa0, 0x0e, 0x9a, 0xbf, 0x9d, 0xf4, 0x0b, 0x1d, 0x40,
-	0x98, 0xdd, 0x5c, 0x29, 0xd4, 0x41, 0xb3, 0xd4, 0xde, 0x4c, 0x67, 0xc3, 0x31, 0x26, 0x36, 0xe3,
-	0xa7, 0x98, 0xf8, 0x84, 0xfa, 0x2c, 0xed, 0x74, 0x72, 0xc9, 0xc6, 0x03, 0x80, 0x95, 0x8f, 0x77,
-	0xab, 0x40, 0x0a, 0xc5, 0xd0, 0x19, 0xfc, 0xd3, 0xe7, 0xfd, 0x9e, 0xf4, 0xc2, 0x11, 0x13, 0x3a,
-	0x46, 0xf8, 0xd1, 0x2c, 0xb5, 0x77, 0xf0, 0x8a, 0xc7, 0xc4, 0xbd, 0x2c, 0xd4, 0xfd, 0x39, 0x7d,
-	0xae, 0x59, 0xce, 0xbb, 0x1e, 0x74, 0xf8, 0x09, 0xfc, 0xd6, 0x4a, 0x78, 0x03, 0x95, 0xa7, 0x6f,
-	0xdf, 0x03, 0xf8, 0x2b, 0xa1, 0x47, 0x77, 0x00, 0x96, 0x72, 0x23, 0xa0, 0xbd, 0x95, 0x90, 0x5f,
-	0xbc, 0x78, 0x75, 0xff, 0x1b, 0x49, 0x83, 0xd6, 0xd8, 0xb8, 0x7e, 0x7c, 0xbd, 0x2d, 0xd4, 0xd0,
-	0x3a, 0x59, 0x56, 0xa4, 0x2b, 0xa0, 0xa3, 0xa5, 0x50, 0xdd, 0xe3, 0xe9, 0xdc, 0x06, 0xb3, 0xb9,
-	0x0d, 0x5e, 0xe6, 0x36, 0xb8, 0x59, 0xd8, 0xd6, 0x6c, 0x61, 0x5b, 0x4f, 0x0b, 0xdb, 0x3a, 0xef,
-	0xf8, 0x5c, 0x0f, 0x42, 0x17, 0x7b, 0x72, 0x94, 0xab, 0x30, 0x14, 0xbb, 0x31, 0x06, 0xb9, 0xca,
-	0xed, 0x14, 0xd1, 0x51, 0xc0, 0x94, 0x5b, 0x4c, 0x96, 0xa8, 0xf3, 0x16, 0x00, 0x00, 0xff, 0xff,
-	0xcf, 0x50, 0xd5, 0xc5, 0xfc, 0x02, 0x00, 0x00,
+	// 450 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x93, 0xc1, 0x8a, 0xd3, 0x40,
+	0x1c, 0xc6, 0x33, 0x51, 0x17, 0x9c, 0x8a, 0x87, 0x41, 0x6a, 0xa9, 0x92, 0x5d, 0x23, 0xac, 0x51,
+	0x74, 0x86, 0xed, 0x1e, 0x5c, 0xaf, 0xcb, 0xa2, 0x78, 0x10, 0x34, 0x07, 0x0f, 0xde, 0x26, 0xc9,
+	0x98, 0x0e, 0xb4, 0x33, 0x69, 0x67, 0x22, 0x16, 0xf1, 0xe2, 0x13, 0x08, 0x3e, 0x87, 0xf8, 0x00,
+	0xbe, 0x40, 0x8f, 0x05, 0x2f, 0x9e, 0x44, 0x5a, 0x2f, 0xbe, 0x85, 0x24, 0x33, 0x6d, 0x52, 0x5b,
+	0x0d, 0x15, 0x6f, 0x93, 0xe4, 0xff, 0x7d, 0xff, 0xdf, 0xf7, 0x31, 0x81, 0x6d, 0x9e, 0x30, 0xa1,
+	0xf9, 0x4b, 0xce, 0xc6, 0x64, 0x94, 0xb3, 0xf1, 0x04, 0x67, 0x63, 0xa9, 0x25, 0xda, 0xa7, 0x83,
+	0x01, 0x17, 0x11, 0xd7, 0x0a, 0xc7, 0x52, 0x0d, 0xa5, 0x8a, 0xa9, 0xea, 0xe3, 0x6a, 0xb8, 0x7b,
+	0x3d, 0x95, 0x32, 0x1d, 0x30, 0x42, 0x33, 0x4e, 0xa8, 0x10, 0x52, 0x53, 0xcd, 0xa5, 0x50, 0x46,
+	0xde, 0xbd, 0x63, 0x44, 0x24, 0xa2, 0x8a, 0x19, 0x5f, 0xf2, 0xea, 0x28, 0x62, 0x9a, 0x1e, 0x91,
+	0x8c, 0xa6, 0x5c, 0x94, 0xc3, 0x76, 0xf6, 0x5a, 0x0d, 0xa1, 0x3a, 0xda, 0x8f, 0x57, 0x52, 0x99,
+	0xca, 0xf2, 0x48, 0x8a, 0x93, 0x79, 0xeb, 0x4f, 0xe0, 0xd5, 0x67, 0x85, 0xe9, 0xe3, 0xd5, 0xb8,
+	0x0a, 0xd9, 0x28, 0x67, 0x4a, 0xa3, 0x36, 0xdc, 0x53, 0x9a, 0xea, 0x5c, 0x75, 0xc0, 0x01, 0x08,
+	0x2e, 0x86, 0xf6, 0x09, 0x3d, 0x84, 0xb0, 0xda, 0xdc, 0x71, 0x0f, 0x40, 0xd0, 0xea, 0x1d, 0xda,
+	0x6c, 0xb8, 0xc0, 0xc4, 0x26, 0xbe, 0xc5, 0xc4, 0x4f, 0x69, 0xca, 0xac, 0x67, 0x58, 0x53, 0xfa,
+	0x9f, 0x01, 0xec, 0x6c, 0xee, 0x56, 0x99, 0x14, 0x8a, 0xa1, 0xe7, 0xf0, 0x52, 0xc2, 0x93, 0x33,
+	0x19, 0xe7, 0x43, 0x26, 0x74, 0x81, 0x70, 0x2e, 0x68, 0xf5, 0xee, 0xe2, 0x86, 0x32, 0xf1, 0x59,
+	0x25, 0x3a, 0x3d, 0x3f, 0xfd, 0xb6, 0xef, 0x84, 0x6b, 0x3e, 0xe8, 0xd1, 0x16, 0xf8, 0x5b, 0x8d,
+	0xf0, 0x06, 0x6a, 0x8d, 0x3e, 0x80, 0xed, 0xdf, 0xe0, 0x97, 0xbd, 0x5d, 0x86, 0x2e, 0x4f, 0x6c,
+	0x67, 0x2e, 0x4f, 0xfc, 0xd1, 0x46, 0xc5, 0x7f, 0x49, 0x09, 0xfe, 0x47, 0xca, 0xde, 0x4f, 0x17,
+	0x5e, 0x28, 0x77, 0xa2, 0x8f, 0x00, 0xb6, 0x6a, 0xfd, 0xa2, 0x93, 0x46, 0xef, 0x3f, 0x5c, 0x87,
+	0xee, 0x83, 0x7f, 0x50, 0x9a, 0x98, 0xfe, 0xed, 0x77, 0x5f, 0x7e, 0x7c, 0x70, 0x6f, 0xa2, 0x1b,
+	0x64, 0x65, 0x41, 0xb6, 0x5e, 0x55, 0x85, 0x3e, 0x01, 0x08, 0x2b, 0x0b, 0x74, 0x7f, 0xd7, 0xa5,
+	0x4b, 0xda, 0x93, 0xdd, 0x85, 0x16, 0x16, 0x97, 0xb0, 0x01, 0x3a, 0x6c, 0x84, 0x25, 0x6f, 0x78,
+	0xf2, 0xf6, 0xf4, 0xc9, 0x74, 0xee, 0x81, 0xd9, 0xdc, 0x03, 0xdf, 0xe7, 0x1e, 0x78, 0xbf, 0xf0,
+	0x9c, 0xd9, 0xc2, 0x73, 0xbe, 0x2e, 0x3c, 0xe7, 0xc5, 0x71, 0xca, 0x75, 0x3f, 0x8f, 0x70, 0x2c,
+	0x87, 0x35, 0x2f, 0x43, 0x73, 0xaf, 0xc0, 0x21, 0xaf, 0xeb, 0xce, 0x7a, 0x92, 0x31, 0x15, 0xed,
+	0x95, 0xff, 0xe5, 0xf1, 0xaf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x93, 0xef, 0x9f, 0xc4, 0x4f, 0x04,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -190,6 +288,7 @@ const _ = grpc.SupportPackageIsVersion4
 type QueryClient interface {
 	// Identifers queries all validators that match the given status.
 	Identifiers(ctx context.Context, in *QueryIdentifiersRequest, opts ...grpc.CallOption) (*QueryIdentifiersResponse, error)
+	Identifier(ctx context.Context, in *QueryIdentifierRequest, opts ...grpc.CallOption) (*QueryIdentifierResponse, error)
 }
 
 type queryClient struct {
@@ -209,10 +308,20 @@ func (c *queryClient) Identifiers(ctx context.Context, in *QueryIdentifiersReque
 	return out, nil
 }
 
+func (c *queryClient) Identifier(ctx context.Context, in *QueryIdentifierRequest, opts ...grpc.CallOption) (*QueryIdentifierResponse, error) {
+	out := new(QueryIdentifierResponse)
+	err := c.cc.Invoke(ctx, "/allinbits.cosmoscash.identifier.Query/Identifier", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Identifers queries all validators that match the given status.
 	Identifiers(context.Context, *QueryIdentifiersRequest) (*QueryIdentifiersResponse, error)
+	Identifier(context.Context, *QueryIdentifierRequest) (*QueryIdentifierResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -221,6 +330,9 @@ type UnimplementedQueryServer struct {
 
 func (*UnimplementedQueryServer) Identifiers(ctx context.Context, req *QueryIdentifiersRequest) (*QueryIdentifiersResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Identifiers not implemented")
+}
+func (*UnimplementedQueryServer) Identifier(ctx context.Context, req *QueryIdentifierRequest) (*QueryIdentifierResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Identifier not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -245,6 +357,24 @@ func _Query_Identifiers_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_Identifier_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryIdentifierRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).Identifier(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/allinbits.cosmoscash.identifier.Query/Identifier",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).Identifier(ctx, req.(*QueryIdentifierRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "allinbits.cosmoscash.identifier.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -252,6 +382,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Identifiers",
 			Handler:    _Query_Identifiers_Handler,
+		},
+		{
+			MethodName: "Identifier",
+			Handler:    _Query_Identifier_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -349,6 +483,69 @@ func (m *QueryIdentifiersResponse) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryIdentifierRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryIdentifierRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryIdentifierRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryIdentifierResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryIdentifierResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryIdentifierResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.DidDocuments.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -393,6 +590,30 @@ func (m *QueryIdentifiersResponse) Size() (n int) {
 		l = m.Pagination.Size()
 		n += 1 + l + sovQuery(uint64(l))
 	}
+	return n
+}
+
+func (m *QueryIdentifierRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryIdentifierResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.DidDocuments.Size()
+	n += 1 + l + sovQuery(uint64(l))
 	return n
 }
 
@@ -616,6 +837,171 @@ func (m *QueryIdentifiersResponse) Unmarshal(dAtA []byte) error {
 				m.Pagination = &query.PageResponse{}
 			}
 			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryIdentifierRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryIdentifierRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryIdentifierRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryIdentifierResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryIdentifierResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryIdentifierResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DidDocuments", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.DidDocuments.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/identifier/types/query.pb.gw.go
+++ b/x/identifier/types/query.pb.gw.go
@@ -69,6 +69,60 @@ func local_request_Query_Identifiers_0(ctx context.Context, marshaler runtime.Ma
 
 }
 
+func request_Query_Identifier_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryIdentifierRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := client.Identifier(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_Identifier_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryIdentifierRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.Identifier(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -95,6 +149,29 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Identifiers_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_Identifier_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_Identifier_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_Identifier_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -159,13 +236,37 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_Identifier_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_Identifier_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_Identifier_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
 var (
-	pattern_Query_Identifiers_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"allinbits", "identity", "identitys"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_Identifiers_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"allinbits", "identifier", "identifiers"}, "", runtime.AssumeColonVerbOpt(true)))
+
+	pattern_Query_Identifier_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"allinbits", "identifier", "identifiers", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 )
 
 var (
 	forward_Query_Identifiers_0 = runtime.ForwardResponseMessage
+
+	forward_Query_Identifier_0 = runtime.ForwardResponseMessage
 )

--- a/x/identifier/types/tx.pb.go
+++ b/x/identifier/types/tx.pb.go
@@ -263,6 +263,82 @@ func (m *MsgAddServiceResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgAddServiceResponse proto.InternalMessageInfo
 
+type MsgDeleteAuthentication struct {
+	Id  string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Key string `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	// owner is the address of the user creating the message
+	Owner string `protobuf:"bytes,3,opt,name=owner,proto3" json:"owner,omitempty"`
+}
+
+func (m *MsgDeleteAuthentication) Reset()         { *m = MsgDeleteAuthentication{} }
+func (m *MsgDeleteAuthentication) String() string { return proto.CompactTextString(m) }
+func (*MsgDeleteAuthentication) ProtoMessage()    {}
+func (*MsgDeleteAuthentication) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c7826d264b5e2237, []int{6}
+}
+func (m *MsgDeleteAuthentication) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgDeleteAuthentication) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgDeleteAuthentication.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgDeleteAuthentication) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgDeleteAuthentication.Merge(m, src)
+}
+func (m *MsgDeleteAuthentication) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgDeleteAuthentication) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgDeleteAuthentication.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgDeleteAuthentication proto.InternalMessageInfo
+
+type MsgDeleteAuthenticationResponse struct {
+}
+
+func (m *MsgDeleteAuthenticationResponse) Reset()         { *m = MsgDeleteAuthenticationResponse{} }
+func (m *MsgDeleteAuthenticationResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgDeleteAuthenticationResponse) ProtoMessage()    {}
+func (*MsgDeleteAuthenticationResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c7826d264b5e2237, []int{7}
+}
+func (m *MsgDeleteAuthenticationResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgDeleteAuthenticationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgDeleteAuthenticationResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgDeleteAuthenticationResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgDeleteAuthenticationResponse.Merge(m, src)
+}
+func (m *MsgDeleteAuthenticationResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgDeleteAuthenticationResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgDeleteAuthenticationResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgDeleteAuthenticationResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgCreateIdentifier)(nil), "allinbits.cosmoscash.identifier.MsgCreateIdentifier")
 	proto.RegisterType((*MsgCreateIdentifierResponse)(nil), "allinbits.cosmoscash.identifier.MsgCreateIdentifierResponse")
@@ -270,40 +346,46 @@ func init() {
 	proto.RegisterType((*MsgAddAuthenticationResponse)(nil), "allinbits.cosmoscash.identifier.MsgAddAuthenticationResponse")
 	proto.RegisterType((*MsgAddService)(nil), "allinbits.cosmoscash.identifier.MsgAddService")
 	proto.RegisterType((*MsgAddServiceResponse)(nil), "allinbits.cosmoscash.identifier.MsgAddServiceResponse")
+	proto.RegisterType((*MsgDeleteAuthentication)(nil), "allinbits.cosmoscash.identifier.MsgDeleteAuthentication")
+	proto.RegisterType((*MsgDeleteAuthenticationResponse)(nil), "allinbits.cosmoscash.identifier.MsgDeleteAuthenticationResponse")
 }
 
 func init() { proto.RegisterFile("identifier/tx.proto", fileDescriptor_c7826d264b5e2237) }
 
 var fileDescriptor_c7826d264b5e2237 = []byte{
-	// 448 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x94, 0xcf, 0xae, 0xd2, 0x40,
-	0x14, 0xc6, 0x3b, 0xd4, 0xab, 0xd7, 0x73, 0xf5, 0x46, 0xe7, 0x62, 0x6c, 0x8a, 0x16, 0xc2, 0x8a,
-	0x8d, 0x6d, 0x02, 0xea, 0xc2, 0xe8, 0x02, 0x65, 0x63, 0x4c, 0x37, 0x75, 0x61, 0xe2, 0xc6, 0x0c,
-	0xed, 0x58, 0x26, 0x81, 0x0e, 0xe9, 0x0c, 0x8a, 0x2f, 0x60, 0x34, 0x71, 0xc1, 0x1b, 0xc8, 0xe3,
-	0xb8, 0x64, 0xe9, 0xd2, 0xc0, 0xc6, 0xa7, 0x30, 0xa6, 0x7f, 0x01, 0xdb, 0x58, 0x24, 0xee, 0x66,
-	0x3a, 0xe7, 0xfb, 0xfa, 0x3b, 0xdf, 0x99, 0x0c, 0x5c, 0x30, 0x8f, 0x06, 0x92, 0xbd, 0x65, 0x34,
-	0xb4, 0xe4, 0xdc, 0x9c, 0x86, 0x5c, 0x72, 0xdc, 0x24, 0xe3, 0x31, 0x0b, 0x86, 0x4c, 0x0a, 0xd3,
-	0xe5, 0x62, 0xc2, 0x85, 0x4b, 0xc4, 0xc8, 0xdc, 0x56, 0xea, 0x75, 0x9f, 0xfb, 0x3c, 0xae, 0xb5,
-	0xa2, 0x55, 0x22, 0xd3, 0x1b, 0x3b, 0x5e, 0xdb, 0x65, 0x72, 0xd8, 0xfe, 0x85, 0xe0, 0xc2, 0x16,
-	0xfe, 0xb3, 0x90, 0x12, 0x49, 0x9f, 0xe7, 0xa7, 0x58, 0x83, 0x2b, 0x2e, 0x0f, 0x24, 0x9d, 0x4b,
-	0x0d, 0xb5, 0x50, 0xe7, 0xaa, 0x93, 0x6d, 0xf1, 0x39, 0xd4, 0x98, 0xa7, 0xd5, 0xe2, 0x8f, 0x35,
-	0xe6, 0xe1, 0x57, 0x70, 0x4e, 0x66, 0x72, 0x14, 0x29, 0x5d, 0x22, 0x19, 0x0f, 0x34, 0xb5, 0xa5,
-	0x76, 0xce, 0xba, 0x96, 0x59, 0x81, 0x6b, 0xf6, 0xf7, 0x64, 0xce, 0x1f, 0x36, 0x78, 0x00, 0xa7,
-	0x82, 0x86, 0xef, 0x98, 0x4b, 0x85, 0x76, 0x29, 0xb6, 0xec, 0x54, 0x5a, 0xbe, 0x4c, 0x04, 0x4e,
-	0xae, 0xc4, 0x75, 0x38, 0xe1, 0xef, 0x03, 0x1a, 0x6a, 0x27, 0x31, 0x71, 0xb2, 0x79, 0x74, 0xfa,
-	0x69, 0xd9, 0x54, 0x7e, 0x2e, 0x9b, 0x4a, 0xfb, 0x2e, 0x34, 0x4a, 0xfa, 0x77, 0xa8, 0x98, 0xf2,
-	0x40, 0xd0, 0xf6, 0x57, 0x04, 0x75, 0x5b, 0xf8, 0x7d, 0xcf, 0xdb, 0xa7, 0x4d, 0x63, 0x40, 0x7f,
-	0x89, 0x21, 0x8a, 0xe8, 0x3f, 0xc4, 0x90, 0x37, 0xa0, 0x96, 0x37, 0x60, 0xc0, 0x9d, 0x32, 0xc0,
-	0xbc, 0x83, 0x2f, 0x08, 0xae, 0x27, 0x05, 0x69, 0x38, 0x05, 0xf4, 0x17, 0x70, 0x2d, 0x8d, 0xeb,
-	0x8d, 0x47, 0x24, 0x49, 0xc1, 0x0f, 0x0f, 0xfb, 0x2c, 0x55, 0x0f, 0x88, 0x24, 0x95, 0xb8, 0xb7,
-	0xe1, 0xd6, 0x1e, 0x4d, 0xc6, 0xd9, 0x5d, 0xa8, 0xa0, 0xda, 0xc2, 0xc7, 0x1f, 0x11, 0xdc, 0x28,
-	0x5c, 0xc7, 0xfb, 0x95, 0x30, 0x25, 0x43, 0xd4, 0x1f, 0x1f, 0xa3, 0xca, 0x80, 0xf0, 0x67, 0x04,
-	0x37, 0x8b, 0x73, 0x7f, 0x70, 0x88, 0x67, 0x41, 0xa6, 0x3f, 0x39, 0x4a, 0x96, 0xb3, 0x48, 0x80,
-	0x9d, 0x01, 0x9a, 0x07, 0x9a, 0xa5, 0xf5, 0xfa, 0xc3, 0x7f, 0xab, 0xcf, 0xfe, 0xfa, 0xd4, 0xfe,
-	0xb6, 0x36, 0xd0, 0x6a, 0x6d, 0xa0, 0x1f, 0x6b, 0x03, 0x2d, 0x36, 0x86, 0xb2, 0xda, 0x18, 0xca,
-	0xf7, 0x8d, 0xa1, 0xbc, 0xee, 0xf9, 0x4c, 0x8e, 0x66, 0x43, 0xd3, 0xe5, 0x13, 0x2b, 0xf7, 0xb6,
-	0x12, 0xef, 0x7b, 0x91, 0xb9, 0x35, 0xb7, 0x76, 0x9f, 0xb0, 0x0f, 0x53, 0x2a, 0x86, 0x97, 0xe3,
-	0x27, 0xa7, 0xf7, 0x3b, 0x00, 0x00, 0xff, 0xff, 0x4c, 0xdd, 0xd2, 0x01, 0xdd, 0x04, 0x00, 0x00,
+	// 499 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0x3f, 0x6f, 0xd3, 0x40,
+	0x14, 0xf7, 0xc5, 0x2d, 0x94, 0x57, 0xa8, 0xca, 0x35, 0xa8, 0x96, 0x0b, 0x4e, 0xc9, 0x94, 0x05,
+	0x5b, 0x6a, 0x01, 0x21, 0x04, 0x12, 0x85, 0x2c, 0x08, 0x79, 0x09, 0x03, 0x12, 0x0c, 0xe8, 0x62,
+	0x1f, 0xce, 0x89, 0xd4, 0x17, 0xf9, 0xae, 0x90, 0x7e, 0x01, 0x04, 0x12, 0x03, 0xe2, 0x0b, 0xd0,
+	0x85, 0xef, 0xc2, 0xd8, 0x91, 0x11, 0x25, 0x0b, 0x9f, 0x02, 0x21, 0xff, 0xbb, 0x24, 0xd8, 0x60,
+	0x13, 0x75, 0x7b, 0xe7, 0x7b, 0xbf, 0x3f, 0xef, 0xa7, 0xe7, 0x83, 0x2d, 0xe6, 0xd3, 0x50, 0xb2,
+	0x57, 0x8c, 0x46, 0x8e, 0x1c, 0xdb, 0xa3, 0x88, 0x4b, 0x8e, 0x5b, 0x64, 0x38, 0x64, 0x61, 0x9f,
+	0x49, 0x61, 0x7b, 0x5c, 0x1c, 0x72, 0xe1, 0x11, 0x31, 0xb0, 0x67, 0x9d, 0x66, 0x33, 0xe0, 0x01,
+	0x4f, 0x7a, 0x9d, 0xb8, 0x4a, 0x61, 0xe6, 0xce, 0x1c, 0xd7, 0xac, 0x4c, 0x2f, 0xdb, 0xbf, 0x10,
+	0x6c, 0xb9, 0x22, 0x78, 0x14, 0x51, 0x22, 0xe9, 0x63, 0x75, 0x8b, 0x0d, 0x38, 0xef, 0xf1, 0x50,
+	0xd2, 0xb1, 0x34, 0xd0, 0x2e, 0xea, 0x5c, 0xe8, 0xe5, 0x47, 0xbc, 0x01, 0x0d, 0xe6, 0x1b, 0x8d,
+	0xe4, 0x63, 0x83, 0xf9, 0xf8, 0x19, 0x6c, 0x90, 0x23, 0x39, 0x88, 0x91, 0x1e, 0x91, 0x8c, 0x87,
+	0x86, 0xbe, 0xab, 0x77, 0xd6, 0xf7, 0x1c, 0xbb, 0xc2, 0xae, 0x7d, 0xb0, 0x00, 0xeb, 0xfd, 0x41,
+	0x83, 0xbb, 0xb0, 0x26, 0x68, 0xf4, 0x86, 0x79, 0x54, 0x18, 0x2b, 0x09, 0x65, 0xa7, 0x92, 0xf2,
+	0x69, 0x0a, 0xe8, 0x29, 0x24, 0x6e, 0xc2, 0x2a, 0x7f, 0x1b, 0xd2, 0xc8, 0x58, 0x4d, 0x1c, 0xa7,
+	0x87, 0xbb, 0x6b, 0xef, 0x4f, 0x5a, 0xda, 0xcf, 0x93, 0x96, 0xd6, 0xbe, 0x06, 0x3b, 0x25, 0xf3,
+	0xf7, 0xa8, 0x18, 0xf1, 0x50, 0xd0, 0xf6, 0x17, 0x04, 0x4d, 0x57, 0x04, 0x07, 0xbe, 0xbf, 0xe8,
+	0x36, 0x8b, 0x01, 0xfd, 0x23, 0x86, 0x38, 0xa2, 0x33, 0x88, 0x41, 0x0d, 0xa0, 0x97, 0x0f, 0x60,
+	0xc1, 0xd5, 0x32, 0x83, 0x6a, 0x82, 0x8f, 0x08, 0x2e, 0xa5, 0x0d, 0x59, 0x38, 0x05, 0xeb, 0x4f,
+	0xe0, 0x62, 0x16, 0xd7, 0x4b, 0x9f, 0x48, 0x92, 0x19, 0xaf, 0x1f, 0xf6, 0x7a, 0x86, 0xee, 0x12,
+	0x49, 0x2a, 0xed, 0x6e, 0xc3, 0x95, 0x05, 0x37, 0xca, 0xe7, 0x0b, 0xd8, 0x76, 0x45, 0xd0, 0xa5,
+	0x43, 0x2a, 0x69, 0x45, 0xd6, 0x9b, 0xa0, 0xbf, 0xa6, 0xc7, 0xd9, 0x0e, 0xc6, 0x65, 0xa5, 0xea,
+	0x75, 0x68, 0xfd, 0x85, 0x3c, 0xd7, 0xdf, 0xfb, 0xba, 0x02, 0xba, 0x2b, 0x02, 0xfc, 0x0e, 0xc1,
+	0x66, 0xe1, 0x77, 0xb8, 0x59, 0x19, 0x46, 0xc9, 0x12, 0x99, 0xf7, 0x96, 0x41, 0xe5, 0x86, 0xf0,
+	0x07, 0x04, 0x97, 0x8b, 0x7b, 0x77, 0xab, 0x0e, 0x67, 0x01, 0x66, 0xde, 0x5f, 0x0a, 0xa6, 0xbc,
+	0x48, 0x80, 0xb9, 0x05, 0xb2, 0x6b, 0x92, 0x65, 0xfd, 0xe6, 0xed, 0xff, 0xeb, 0x57, 0xaa, 0x9f,
+	0x11, 0x34, 0x4b, 0x17, 0xe2, 0x4e, 0x1d, 0xc2, 0x32, 0xa4, 0xf9, 0x60, 0x59, 0x64, 0x6e, 0xea,
+	0xa1, 0xfb, 0x6d, 0x62, 0xa1, 0xd3, 0x89, 0x85, 0x7e, 0x4c, 0x2c, 0xf4, 0x69, 0x6a, 0x69, 0xa7,
+	0x53, 0x4b, 0xfb, 0x3e, 0xb5, 0xb4, 0xe7, 0xfb, 0x01, 0x93, 0x83, 0xa3, 0xbe, 0xed, 0xf1, 0x43,
+	0x47, 0xa9, 0x38, 0xa9, 0xca, 0x8d, 0x58, 0xc6, 0x19, 0x3b, 0xf3, 0xef, 0xfa, 0xf1, 0x88, 0x8a,
+	0xfe, 0xb9, 0xe4, 0x1d, 0xde, 0xff, 0x1d, 0x00, 0x00, 0xff, 0xff, 0xcb, 0x34, 0x24, 0x08, 0xf2,
+	0x05, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -322,6 +404,7 @@ type MsgClient interface {
 	CreateIdentifier(ctx context.Context, in *MsgCreateIdentifier, opts ...grpc.CallOption) (*MsgCreateIdentifierResponse, error)
 	AddAuthentication(ctx context.Context, in *MsgAddAuthentication, opts ...grpc.CallOption) (*MsgAddAuthenticationResponse, error)
 	AddService(ctx context.Context, in *MsgAddService, opts ...grpc.CallOption) (*MsgAddServiceResponse, error)
+	DeleteAuthentication(ctx context.Context, in *MsgDeleteAuthentication, opts ...grpc.CallOption) (*MsgDeleteAuthenticationResponse, error)
 }
 
 type msgClient struct {
@@ -359,12 +442,22 @@ func (c *msgClient) AddService(ctx context.Context, in *MsgAddService, opts ...g
 	return out, nil
 }
 
+func (c *msgClient) DeleteAuthentication(ctx context.Context, in *MsgDeleteAuthentication, opts ...grpc.CallOption) (*MsgDeleteAuthenticationResponse, error) {
+	out := new(MsgDeleteAuthenticationResponse)
+	err := c.cc.Invoke(ctx, "/allinbits.cosmoscash.identifier.Msg/DeleteAuthentication", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	// CreateDidDocument defines a method for creating a new identity.
 	CreateIdentifier(context.Context, *MsgCreateIdentifier) (*MsgCreateIdentifierResponse, error)
 	AddAuthentication(context.Context, *MsgAddAuthentication) (*MsgAddAuthenticationResponse, error)
 	AddService(context.Context, *MsgAddService) (*MsgAddServiceResponse, error)
+	DeleteAuthentication(context.Context, *MsgDeleteAuthentication) (*MsgDeleteAuthenticationResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -379,6 +472,9 @@ func (*UnimplementedMsgServer) AddAuthentication(ctx context.Context, req *MsgAd
 }
 func (*UnimplementedMsgServer) AddService(ctx context.Context, req *MsgAddService) (*MsgAddServiceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AddService not implemented")
+}
+func (*UnimplementedMsgServer) DeleteAuthentication(ctx context.Context, req *MsgDeleteAuthentication) (*MsgDeleteAuthenticationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteAuthentication not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -439,6 +535,24 @@ func _Msg_AddService_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_DeleteAuthentication_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgDeleteAuthentication)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).DeleteAuthentication(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/allinbits.cosmoscash.identifier.Msg/DeleteAuthentication",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).DeleteAuthentication(ctx, req.(*MsgDeleteAuthentication))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "allinbits.cosmoscash.identifier.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -454,6 +568,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AddService",
 			Handler:    _Msg_AddService_Handler,
+		},
+		{
+			MethodName: "DeleteAuthentication",
+			Handler:    _Msg_DeleteAuthentication_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -699,6 +817,73 @@ func (m *MsgAddServiceResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgDeleteAuthentication) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgDeleteAuthentication) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgDeleteAuthentication) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Owner) > 0 {
+		i -= len(m.Owner)
+		copy(dAtA[i:], m.Owner)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Owner)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgDeleteAuthenticationResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgDeleteAuthenticationResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgDeleteAuthenticationResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -804,6 +989,36 @@ func (m *MsgAddService) Size() (n int) {
 }
 
 func (m *MsgAddServiceResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgDeleteAuthentication) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Key)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Owner)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *MsgDeleteAuthenticationResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1459,6 +1674,202 @@ func (m *MsgAddServiceResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgAddServiceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgDeleteAuthentication) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgDeleteAuthentication: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgDeleteAuthentication: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Owner", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Owner = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgDeleteAuthenticationResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgDeleteAuthenticationResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgDeleteAuthenticationResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
### Description 

Added ability to remove public keys from did document

### How to test

- `make install`
- `make init-dev`
- `make start-dev`

In another terminal

- `./scripts/seeds/01_identifier_seeds.sh`

### Expected output
```
{
  "didDocuments": [
    {
      "context": "https://www.w3.org/ns/did/v1",
      "id": "did:cash:cosmos1m2u0n8ukqr9ugue36lm43xelrcr2pp8tg7z7s0",
      "authentication": [
        {
          "id": "did:cash:cosmos1m2u0n8ukqr9ugue36lm43xelrcr2pp8tg7z7s0#keys-1",
          "type": "sepk256",
          "controller": "cosmos1m2u0n8ukqr9ugue36lm43xelrcr2pp8tg7z7s0",
          "publicKey": "Amhza8XNqOlzA3Q3gHWMugjaa3Ue79pSVelTxM0iWS2H"
        }
      ],
      "services": [
        {
          "id": "new-verifiable-cred-3",
          "type": "KYCCredential",
          "serviceEndpoint": "cosmos-cash:new-verifiable-cred-3"
        }
      ]
    }
  ],
  "pagination": null
}

```