### PR TITLE
feat(tests): increase vcs keeper test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# cosmos-cash
+# Cosmos Cash
+
+![](https://miro.medium.com/max/1000/1*8Wx44uvyJxpZUVS0WojMNw.png)
+
+### Summary
 
 Cosmos Cash is a protocol designed to be regulatory compliant that offers the same guarantees as traditional banking systems. Features that enable these guarantees are KYC (Know your customer), AML (Anti-Money Laundering) tracking, FAFT travel rule, and identity management. We use a novel approach to identity management by leveraging W3C specifications for decentralized identifiers and verifiable credentials.
 
@@ -10,4 +14,8 @@ Cosmos Cash is a protocol designed to be regulatory compliant that offers the sa
 ### How to run the chain
 
 - `make start-dev`
+
+### How to seed the chain
+
+- `make seed`
 

--- a/scripts/seeds/00_start_chain.sh
+++ b/scripts/seeds/00_start_chain.sh
@@ -1,13 +1,31 @@
 #!/bin/bash
 
-echo "Initialising chain"
-cosmos-cashd init --chain-id=cash cash 
-echo "y" | cosmos-cashd keys add validator
+GENESIS_FILE=~/.cosmoscash/config/genesis.json
+if [ -f $GENESIS_FILE ]
+then
+    echo "Genesis file exist, would you like to delete it? (y/n)"
+    read delete_config
+fi
 
-echo "Adding genesis account"
-cosmos-cashd add-genesis-account $(cosmos-cashd keys show validator -a) 1000000000stake
-cosmos-cashd gentx validator 700000000stake --chain-id cash
-cosmos-cashd collect-gentxs 
+if [[
+	$delete_config == "Y" ||
+	$delete_config == "y" ||
+	! -f $GENESIS_FILE
+   ]];
+then
+    rm -r ~/.cosmoscash
+
+    echo "Initialising chain"
+    cosmos-cashd init --chain-id=cash cash
+    echo "y" | cosmos-cashd keys add validator
+
+    echo "Adding genesis account"
+    cosmos-cashd add-genesis-account $(cosmos-cashd keys show validator -a) 1000000000stake
+    cosmos-cashd gentx validator 700000000stake --chain-id cash
+    cosmos-cashd collect-gentxs
+fi
+
 
 echo "Starting cosmos cash chain"
-cosmos-cashd start 
+cosmos-cashd start
+

--- a/x/verifiable-credential-service/keeper/grpc_query_test.go
+++ b/x/verifiable-credential-service/keeper/grpc_query_test.go
@@ -1,0 +1,188 @@
+package keeper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/allinbits/cosmos-cash/x/verifiable-credential-service/types"
+)
+
+func (suite *KeeperTestSuite) TestGRPCQueryVerifiableCredentials() {
+	queryClient := suite.queryClient
+	var req *types.QueryVerifiableCredentialsRequest
+	testCases := []struct {
+		msg      string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"Pass: will return an empty array",
+			func() {
+				req = &types.QueryVerifiableCredentialsRequest{}
+			},
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			tc.malleate()
+			identifiersResp, err := queryClient.VerifiableCredentials(context.Background(), req)
+			if tc.expPass {
+				suite.NoError(err)
+				suite.NotNil(identifiersResp)
+
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestGRPCQueryVerifiableCredential() {
+	queryClient := suite.queryClient
+	var req *types.QueryVerifiableCredentialRequest
+	testCases := []struct {
+		msg      string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"Fail: will fail because no id is provided",
+			func() {
+				req = &types.QueryVerifiableCredentialRequest{}
+			},
+			false,
+		},
+		{
+			"Fail: will fail because no vc is found",
+			func() {
+				req = &types.QueryVerifiableCredentialRequest{
+					VerifiableCredentialId: "vc:cash:1234",
+				}
+			},
+			false,
+		},
+		{
+			"Pass: will pass because a vc is found",
+			func() {
+				cs := types.NewCredentialSubject(
+					"accAddr",
+					true,
+				)
+
+				vc := types.NewVerifiableCredential(
+					"new-verifiable-cred-3",
+					[]string{"VerifiableCredential", "KYCCredential"},
+					"accAddr",
+					fmt.Sprintf("%s", "currentTome"),
+					cs,
+					types.NewProof("", "", "", "", ""),
+				)
+				suite.keeper.SetVerifiableCredential(
+					suite.ctx,
+					[]byte(vc.Id),
+					vc,
+				)
+				req = &types.QueryVerifiableCredentialRequest{
+					VerifiableCredentialId: vc.Id,
+				}
+			},
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			tc.malleate()
+			identifiersResp, err := queryClient.VerifiableCredential(context.Background(), req)
+			if tc.expPass {
+				suite.NoError(err)
+				suite.NotNil(identifiersResp)
+
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestGRPCQueryValidateVerifiableCredential() {
+	queryClient := suite.queryClient
+	var req *types.QueryValidateVerifiableCredentialRequest
+	testCases := []struct {
+		msg      string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"Fail: will fail because no id is provided",
+			func() {
+				req = &types.QueryValidateVerifiableCredentialRequest{}
+			},
+			false,
+		},
+		{
+			"Fail: will fail because no vc is found",
+			func() {
+				req = &types.QueryValidateVerifiableCredentialRequest{
+					VerifiableCredentialId: "vc:cash:1234",
+				}
+			},
+			false,
+		},
+		{
+			"Pass: will pass because a vc is found and valid",
+			func() {
+				// NOTE: The signature is hardcoded here for simplicity, if changing this test in the
+				// future please find a better way of generting the signature
+				issuerPubkey := "cosmospub1addwnpepqg86fqwehwcjndtcluzs32eel0m4lcsghx6dkxrreqyrey4w7aqju0ks4l8"
+				signature := "HjxPB1hv/iFjnvA5c3GGSfxi8YyzaKb8qqvBk8yBPa1DPG1VV/JzowVlTSyaO3YBBxAlb6dpRfeP8SfkHjcNQQ=="
+
+				cs := types.NewCredentialSubject(
+					"accAddr",
+					true,
+				)
+
+				vc := types.NewVerifiableCredential(
+					"new-verifiable-cred-3",
+					[]string{"VerifiableCredential", "KYCCredential"},
+					"accAddr",
+					fmt.Sprintf("%s", "currentTime"),
+					cs,
+					types.NewProof("", "", "", "", ""),
+				)
+
+				p := types.NewProof(
+					"sepk256",
+					fmt.Sprintf("%s", "tm"),
+					"assertionMethod",
+					"accAddrBech32"+"#keys-1",
+					signature,
+				)
+				vc.Proof = &p
+				suite.keeper.SetVerifiableCredential(
+					suite.ctx,
+					[]byte(vc.Id),
+					vc,
+				)
+				req = &types.QueryValidateVerifiableCredentialRequest{
+					VerifiableCredentialId: vc.Id,
+					IssuerPubkey:           issuerPubkey,
+				}
+			},
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			tc.malleate()
+			identifiersResp, err := queryClient.ValidateVerifiableCredential(context.Background(), req)
+			if tc.expPass {
+				suite.NoError(err)
+				suite.NotNil(identifiersResp)
+
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}

--- a/x/verifiable-credential-service/keeper/msg_server_test.go
+++ b/x/verifiable-credential-service/keeper/msg_server_test.go
@@ -1,0 +1,76 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/allinbits/cosmos-cash/x/verifiable-credential-service/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (suite *KeeperTestSuite) TestMsgSeverCreateVerifableCredential() {
+	server := NewMsgServerImpl(suite.keeper)
+	var req types.MsgCreateVerifiableCredential
+
+	testCases := []struct {
+		msg      string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"correctly creates vc",
+			func() {
+				cs := types.NewCredentialSubject(
+					"accAddr",
+					true,
+				)
+
+				vc := types.NewVerifiableCredential(
+					"new-verifiable-cred-3",
+					[]string{"VerifiableCredential", "KYCCredential"},
+					"accAddr",
+					fmt.Sprintf("%s", "currentTome"),
+					cs,
+					types.NewProof("", "", "", "", ""),
+				)
+				req = *types.NewMsgCreateVerifiableCredential(vc, "did:cash:1111")
+			},
+			true,
+		},
+		{
+			"vc already exists",
+			func() {
+				cs := types.NewCredentialSubject(
+					"accAddr",
+					true,
+				)
+
+				vc := types.NewVerifiableCredential(
+					"new-verifiable-cred-3",
+					[]string{"VerifiableCredential", "KYCCredential"},
+					"accAddr",
+					fmt.Sprintf("%s", "currentTome"),
+					cs,
+					types.NewProof("", "", "", "", ""),
+				)
+				suite.keeper.SetVerifiableCredential(suite.ctx, []byte(vc.Id), vc)
+
+				req = *types.NewMsgCreateVerifiableCredential(vc, "did:cash:1111")
+			},
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			tc.malleate()
+
+			vcResp, err := server.CreateVerifiableCredential(sdk.WrapSDKContext(suite.ctx), &req)
+			if tc.expPass {
+				suite.NoError(err)
+				suite.NotNil(vcResp)
+
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
+}

--- a/x/verifiable-credential-service/keeper/verifiable-credential_test.go
+++ b/x/verifiable-credential-service/keeper/verifiable-credential_test.go
@@ -1,0 +1,58 @@
+package keeper
+
+import (
+	"fmt"
+	"github.com/allinbits/cosmos-cash/x/verifiable-credential-service/types"
+)
+
+func (suite *KeeperTestSuite) TestVerifiableCredentialsKeeperSetAndGet() {
+	testCases := []struct {
+		msg string
+		vc  types.VerifiableCredential
+		// TODO: add mallate func and clean up test
+		expPass bool
+	}{
+		{
+			"data stored successfully",
+			types.NewVerifiableCredential(
+				"did:cash:1111",
+				[]string{"context"},
+				"",
+				"",
+				types.NewCredentialSubject("", true),
+				types.NewProof("", "", "", "", ""),
+			),
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		suite.keeper.SetVerifiableCredential(
+			suite.ctx,
+			[]byte(tc.vc.Id),
+			tc.vc,
+		)
+		suite.keeper.SetVerifiableCredential(
+			suite.ctx,
+			[]byte(tc.vc.Id+"1"),
+			tc.vc,
+		)
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			if tc.expPass {
+				_, found := suite.keeper.GetVerifiableCredential(
+					suite.ctx,
+					[]byte(tc.vc.Id),
+				)
+				suite.Require().True(found)
+
+				array := suite.keeper.GetAllVerifiableCredentials(
+					suite.ctx,
+				)
+
+				suite.Require().Equal(2, len(array))
+			} else {
+				// TODO write failure cases
+				suite.Require().False(tc.expPass)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

- increase verifiable credentials keeper test coverage to more than 80%

### How to test

- `make test`

### Output

```sh
ok  	github.com/allinbits/cosmos-cash/x/verifiable-credential-service/client/cli	(cached)	coverage: 17.2% of statements
ok  	github.com/allinbits/cosmos-cash/x/verifiable-credential-service/keeper	0.031s	coverage: 82.4% of statements

```