### PR TITLE
feat(issuer): use ante handler for issuer authorization

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	identifierkeeper "github.com/allinbits/cosmos-cash/x/identifier/keeper"
+	issuerante "github.com/allinbits/cosmos-cash/x/issuer/ante"
+	issuerkeeper "github.com/allinbits/cosmos-cash/x/issuer/keeper"
+	vcskeeper "github.com/allinbits/cosmos-cash/x/verifiable-credential-service/keeper"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// NewAnteHandler returns an AnteHandler that checks and increments sequence
+// numbers, checks signatures & account numbers, and deducts fees from the first
+// signer.
+func NewAnteHandler(
+	ak authante.AccountKeeper, bankKeeper authtypes.BankKeeper,
+	ik issuerkeeper.Keeper,
+	dk identifierkeeper.Keeper,
+	vcsk vcskeeper.Keeper,
+	sigGasConsumer authante.SignatureVerificationGasConsumer,
+	signModeHandler signing.SignModeHandler,
+) sdk.AnteHandler {
+	return sdk.ChainAnteDecorators(
+		authante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		authante.NewRejectExtensionOptionsDecorator(),
+		authante.NewMempoolFeeDecorator(),
+		authante.NewValidateBasicDecorator(),
+		authante.TxTimeoutHeightDecorator{},
+		authante.NewValidateMemoDecorator(ak),
+		authante.NewConsumeGasForTxSizeDecorator(ak),
+		authante.NewRejectFeeGranterDecorator(),
+		authante.NewSetPubKeyDecorator(ak), // SetPubKeyDecorator must be called before all signature verification decorators
+		authante.NewValidateSigCountDecorator(ak),
+		authante.NewDeductFeeDecorator(ak, bankKeeper),
+		authante.NewSigGasConsumeDecorator(ak, sigGasConsumer),
+		authante.NewSigVerificationDecorator(ak, signModeHandler),
+		issuerante.NewCheckIssuerCredentialsDecorator(ik, dk, vcsk),
+	)
+}

--- a/app/app.go
+++ b/app/app.go
@@ -197,7 +197,7 @@ type App struct {
 	ScopedTransferKeeper capabilitykeeper.ScopedKeeper
 
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
-	issuerKeeper        issuerkeeper.Keeper
+	IssuerKeeper        issuerkeeper.Keeper
 	VcsKeeper           vcskeeper.Keeper
 	ibcidentifierKeeper ibcidentifierkeeper.Keeper
 	IdentifierKeeper    identifierkeeper.Keeper
@@ -436,7 +436,7 @@ func New(
 		keys[vcstypes.StoreKey],
 		keys[vcstypes.MemStoreKey],
 	)
-	app.issuerKeeper = *issuerkeeper.NewKeeper(
+	app.IssuerKeeper = *issuerkeeper.NewKeeper(
 		appCodec,
 		keys[issuertypes.StoreKey],
 		keys[issuertypes.MemStoreKey],
@@ -520,7 +520,7 @@ func New(
 		// this line is used by starport scaffolding # stargate/app/appModule
 		issuer.NewAppModule(
 			appCodec,
-			app.issuerKeeper,
+			app.IssuerKeeper,
 		),
 		vcs.NewAppModule(
 			appCodec,
@@ -601,7 +601,7 @@ func New(
 		NewAnteHandler(
 			app.AccountKeeper,
 			app.BankKeeper,
-			app.issuerKeeper,
+			app.IssuerKeeper,
 			app.IdentifierKeeper,
 			app.VcsKeeper,
 			ante.DefaultSigVerificationGasConsumer,

--- a/app/app.go
+++ b/app/app.go
@@ -440,8 +440,6 @@ func New(
 		appCodec,
 		keys[issuertypes.StoreKey],
 		keys[issuertypes.MemStoreKey],
-		app.IdentifierKeeper,
-		app.VcsKeeper,
 		app.BankKeeper,
 	)
 
@@ -600,9 +598,12 @@ func New(
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetAnteHandler(
-		ante.NewAnteHandler(
+		NewAnteHandler(
 			app.AccountKeeper,
 			app.BankKeeper,
+			app.issuerKeeper,
+			app.IdentifierKeeper,
+			app.VcsKeeper,
 			ante.DefaultSigVerificationGasConsumer,
 			encodingConfig.TxConfig.SignModeHandler(),
 		),

--- a/x/issuer/ante/ante.go
+++ b/x/issuer/ante/ante.go
@@ -1,0 +1,92 @@
+package ante
+
+import (
+	"fmt"
+	identifierkeeper "github.com/allinbits/cosmos-cash/x/identifier/keeper"
+	vcskeeper "github.com/allinbits/cosmos-cash/x/verifiable-credential-service/keeper"
+	//identifiertypes "github.com/allinbits/cosmos-cash/x/identifier/types"
+	"github.com/allinbits/cosmos-cash/x/issuer/keeper"
+	"github.com/allinbits/cosmos-cash/x/issuer/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	//bank "github.com/cosmos/cosmos-sdk/x/bank"
+)
+
+// CheckIssuerCredentialsDecorator deducts fees from the every send transaction
+type CheckIssuerCredentialsDecorator struct {
+	issuerk keeper.Keeper
+	ik      identifierkeeper.Keeper
+	vcsk    vcskeeper.Keeper
+}
+
+func NewCheckIssuerCredentialsDecorator(
+	issuerk keeper.Keeper,
+	ik identifierkeeper.Keeper,
+	vcsk vcskeeper.Keeper,
+) CheckIssuerCredentialsDecorator {
+	return CheckIssuerCredentialsDecorator{
+		issuerk: issuerk,
+		ik:      ik,
+		vcsk:    vcsk,
+	}
+}
+
+func (cicd CheckIssuerCredentialsDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	for _, msg := range tx.GetMsgs() {
+		if msg.Type() == "create-issuer" {
+			imsg := msg.(*types.MsgCreateIssuer)
+
+			// TODO: pass in the did URI as an arg {msg.Id}
+			// TODO: ensure this keeper can only read from store
+			did, found := cicd.ik.GetIdentifier(ctx, []byte("did:cash:"+imsg.Owner))
+			if !found {
+				return ctx, sdkerrors.Wrapf(
+					types.ErrIssuerFound,
+					"identifer does not exists",
+				)
+			}
+
+			// TODO: optimise here
+			foundKey := false
+			for _, auth := range did.Authentication {
+				if auth.Controller == imsg.Owner {
+					fmt.Println("found key")
+					foundKey = true
+				}
+			}
+			if !foundKey {
+				return ctx, sdkerrors.Wrapf(
+					types.ErrIssuerFound,
+					"msg sender not in auth array in did document",
+				)
+			}
+
+			// TODO: optimise here
+			// check if the did document has the issuer credential
+			hasIssuerCredential := false
+			for _, service := range did.Services {
+				// TODO use enum here
+				if service.Type == "KYCCredential" {
+					// TODO: ensure this keeper can only read from store
+					vc, found := cicd.vcsk.GetVerifiableCredential(ctx, []byte(service.Id))
+					if !found {
+						return ctx, sdkerrors.Wrapf(
+							types.ErrIssuerFound,
+							"credential not found",
+						)
+					}
+					hasIssuerCredential = vc.CredentialSubject.HasKyc
+					// TODO: validate credential here
+				}
+			}
+			if !hasIssuerCredential {
+				return ctx, sdkerrors.Wrapf(
+					types.ErrIssuerFound,
+					"did document doesnt have a credential to create issuers",
+				)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/x/issuer/client/cli/cli_test.go
+++ b/x/issuer/client/cli/cli_test.go
@@ -1,0 +1,113 @@
+package cli_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/suite"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/allinbits/cosmos-cash/x/issuer/client/cli"
+	"github.com/allinbits/cosmos-cash/x/issuer/types"
+	//"github.com/cosmos/cosmos-sdk/client/flags"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
+	//sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/allinbits/cosmos-cash/app"
+	"github.com/allinbits/cosmos-cash/app/params"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	dbm "github.com/tendermint/tm-db"
+)
+
+// NewAppConstructor returns a new simapp AppConstructor
+func NewAppConstructor(encodingCfg params.EncodingConfig) network.AppConstructor {
+	return func(val network.Validator) servertypes.Application {
+		return app.New(
+			"cosmos-cash",
+			val.Ctx.Logger,
+			dbm.NewMemDB(), nil, true, make(map[int64]bool),
+			val.Ctx.Config.RootDir,
+			0,
+			encodingCfg,
+			simapp.EmptyAppOptions{},
+			baseapp.SetPruning(storetypes.NewPruningOptionsFromString(val.AppConfig.Pruning)),
+			baseapp.SetMinGasPrices(val.AppConfig.MinGasPrices),
+		)
+	}
+}
+
+type IntegrationTestSuite struct {
+	suite.Suite
+
+	cfg     network.Config
+	network *network.Network
+}
+
+// SetupSuite executes bootstrapping logic before all the tests, i.e. once before
+// the entire suite, start executing.
+func (s *IntegrationTestSuite) SetupSuite() {
+	s.T().Log("setting up integration test suite")
+	cfg := network.DefaultConfig()
+	types.RegisterInterfaces(cfg.InterfaceRegistry)
+	cfg.AppConstructor = NewAppConstructor(app.MakeEncodingConfig())
+	cfg.NumValidators = 2
+
+	s.cfg = cfg
+	s.network = network.New(s.T(), cfg)
+
+	_, err := s.network.WaitForHeight(1)
+	s.Require().NoError(err)
+}
+
+// TearDownSuite performs cleanup logic after all the tests, i.e. once after the
+// entire suite, has finished executing.
+func (s *IntegrationTestSuite) TearDownSuite() {
+	s.T().Log("tearing down integration test suite")
+	s.network.Cleanup()
+}
+
+func (s *IntegrationTestSuite) TestGetCmdQueryIssuers() {
+	val := s.network.Validators[0]
+
+	testCases := []struct {
+		name      string
+		args      []string
+		expectErr bool
+		respType  proto.Message
+		expected  proto.Message
+	}{
+		{
+			"json output",
+			[]string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
+			false,
+			&types.QueryIssuersResponse{},
+			&types.QueryIssuersResponse{},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			cmd := cli.GetCmdQueryIssuers()
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Require().NoError(clientCtx.JSONMarshaler.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().Equal(tc.expected.String(), tc.respType.String())
+
+			}
+		})
+	}
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}

--- a/x/issuer/keeper/keeper.go
+++ b/x/issuer/keeper/keeper.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 
-	identifierkeeper "github.com/allinbits/cosmos-cash/x/identifier/keeper"
 	"github.com/allinbits/cosmos-cash/x/issuer/types"
-	vcskeeper "github.com/allinbits/cosmos-cash/x/verifiable-credential-service/keeper"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -24,25 +22,19 @@ type Keeper struct {
 	storeKey sdk.StoreKey
 	memKey   sdk.StoreKey
 
-	ik   identifierkeeper.Keeper
-	vcsk vcskeeper.Keeper
-	bk   bank.Keeper
+	bk bank.Keeper
 }
 
 func NewKeeper(
 	cdc codec.Marshaler,
 	storeKey,
 	memKey sdk.StoreKey,
-	ik identifierkeeper.Keeper,
-	vcsk vcskeeper.Keeper,
 	bk bank.Keeper,
 ) *Keeper {
 	return &Keeper{
 		cdc:      cdc,
 		storeKey: storeKey,
 		memKey:   memKey,
-		ik:       ik,
-		vcsk:     vcsk,
 		bk:       bk,
 	}
 }

--- a/x/issuer/keeper/keeper_test.go
+++ b/x/issuer/keeper/keeper_test.go
@@ -1,0 +1,163 @@
+package keeper
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/suite"
+	"testing"
+
+	"github.com/allinbits/cosmos-cash/x/issuer/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	ct "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	dbm "github.com/tendermint/tm-db"
+)
+
+// Keeper test suit enables the keeper package to be tested
+type KeeperTestSuite struct {
+	suite.Suite
+
+	ctx         sdk.Context
+	keeper      Keeper
+	queryClient types.QueryClient
+}
+
+// SetupTest creates a test suite to test the issuer
+func (suite *KeeperTestSuite) SetupTest() {
+	keyIssuer := sdk.NewKVStoreKey(types.StoreKey)
+	memKeyIssuer := sdk.NewKVStoreKey(types.MemStoreKey)
+	keyAcc := sdk.NewKVStoreKey(authtypes.StoreKey)
+	keyBank := sdk.NewKVStoreKey(banktypes.StoreKey)
+	keyParams := sdk.NewKVStoreKey(paramtypes.StoreKey)
+	memKeyParams := sdk.NewKVStoreKey(paramtypes.TStoreKey)
+
+	db := dbm.NewMemDB()
+	ms := store.NewCommitMultiStore(db)
+	ms.MountStoreWithDB(keyIssuer, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(memKeyIssuer, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(keyAcc, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(keyBank, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(keyParams, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(memKeyParams, sdk.StoreTypeIAVL, db)
+	_ = ms.LoadLatestVersion()
+
+	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "foochainid"}, true, nil)
+
+	interfaceRegistry := ct.NewInterfaceRegistry()
+	marshaler := codec.NewProtoCodec(interfaceRegistry)
+
+	maccPerms := map[string][]string{
+		authtypes.FeeCollectorName: nil,
+		types.ModuleName:           {authtypes.Minter, authtypes.Burner},
+	}
+
+	allowedReceivingModAcc := map[string]bool{}
+
+	blockedAddrs := make(map[string]bool)
+	for acc := range maccPerms {
+		blockedAddrs[authtypes.NewModuleAddress(acc).String()] = !allowedReceivingModAcc[acc]
+	}
+
+	paramsKeeper := paramskeeper.NewKeeper(marshaler, nil, keyParams, memKeyParams)
+
+	AccountKeeper := authkeeper.NewAccountKeeper(
+		marshaler,
+		keyAcc,
+		paramsKeeper.Subspace(authtypes.ModuleName),
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+	)
+
+	BankKeeper := bankkeeper.NewBaseKeeper(
+		marshaler,
+		keyBank,
+		AccountKeeper,
+		paramsKeeper.Subspace(banktypes.ModuleName),
+		blockedAddrs,
+	)
+
+	k := NewKeeper(
+		marshaler,
+		keyIssuer,
+		memKeyIssuer,
+		BankKeeper,
+	)
+
+	queryHelper := baseapp.NewQueryServerTestHelper(ctx, interfaceRegistry)
+	types.RegisterQueryServer(queryHelper, k)
+	queryClient := types.NewQueryClient(queryHelper)
+
+	suite.ctx, suite.keeper, suite.queryClient = ctx, *k, queryClient
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (suite *KeeperTestSuite) TestGenericKeeperSetAndGet() {
+	testCases := []struct {
+		msg     string
+		issuer  types.Issuer
+		expPass bool
+	}{
+		{
+			"data stored successfully",
+			types.Issuer{
+				"context",
+				10,
+				"did:cash:1111",
+			},
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		suite.keeper.Set(suite.ctx,
+			[]byte(tc.issuer.Address),
+			[]byte{0x01},
+			tc.issuer,
+			suite.keeper.MarshalIssuer,
+		)
+		suite.keeper.Set(suite.ctx,
+			[]byte(tc.issuer.Address+"1"),
+			[]byte{0x01},
+			tc.issuer,
+			suite.keeper.MarshalIssuer,
+		)
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			if tc.expPass {
+				_, found := suite.keeper.Get(
+					suite.ctx,
+					[]byte(tc.issuer.Address),
+					[]byte{0x01},
+					suite.keeper.UnmarshalIssuer,
+				)
+				suite.Require().True(found)
+
+				iterator := suite.keeper.GetAll(
+					suite.ctx,
+					[]byte{0x01},
+				)
+				defer iterator.Close()
+
+				var array []interface{}
+				for ; iterator.Valid(); iterator.Next() {
+					array = append(array, iterator.Value())
+				}
+				suite.Require().Equal(2, len(array))
+			} else {
+				// TODO write failure cases
+				suite.Require().False(tc.expPass)
+			}
+		})
+	}
+}

--- a/x/issuer/module_test.go
+++ b/x/issuer/module_test.go
@@ -1,0 +1,40 @@
+package issuer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/allinbits/cosmos-cash/app"
+	"github.com/tendermint/tendermint/libs/log"
+
+	"github.com/cosmos/cosmos-sdk/simapp"
+
+	dbm "github.com/tendermint/tm-db"
+)
+
+// TODO: add more test cases
+func TestCreateModuleInApp(t *testing.T) {
+	app := app.New(
+		"cosmos-cash",
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		nil,
+		true,
+		make(map[int64]bool),
+		app.DefaultNodeHome("cosmoscash"),
+		0,
+		app.MakeEncodingConfig(),
+		simapp.EmptyAppOptions{},
+	)
+
+	app.InitChain(
+		abcitypes.RequestInitChain{
+			AppStateBytes: []byte("{}"),
+			ChainId:       "test-chain-id",
+		},
+	)
+
+	require.NotNil(t, app.IdentifierKeeper)
+}

--- a/x/issuer/types/msg.go
+++ b/x/issuer/types/msg.go
@@ -7,7 +7,7 @@ import (
 
 // msg types
 const (
-	TypeMsgCreateIssuer = "create-identifier"
+	TypeMsgCreateIssuer = "create-issuer"
 )
 
 var _ sdk.Msg = &MsgCreateIssuer{}


### PR DESCRIPTION
### Description

Move auth logic from issuer msg_server.go to issuer ante.go

### Issue

N/A

### How to test

- `make start-dev`

In another terminal

- `./scripts/seeds/03_issuer_seeds.sh`

:arrow_double_up:  see errors

- `make seeds`
- `./scripts/seeds/03_issuer_seeds.sh`

:arrow_double_up: will pass