### PR TITLE
feat(tests): integration tests for verifiable credential module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,5 @@ start-dev: install
 seed: 
 	./scripts/seeds/01_identifier_seeds.sh
 	./scripts/seeds/02_verifiable_credentials_seeds.sh
+	./scripts/seeds/03_issuer_seeds.sh
 

--- a/scripts/seeds/02_verifiable_credentials_seeds.sh
+++ b/scripts/seeds/02_verifiable_credentials_seeds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Creating verifiable credential for user :validator"
-cosmos-cashd tx verifiablecredentialservice create-verifiable-credential did:cash:$(cosmos-cashd keys show validator -a) --from validator --chain-id cash -y
+cosmos-cashd tx verifiablecredentialservice create-verifiable-credential did:cash:$(cosmos-cashd keys show validator -a) new-verifiable-cred-3 --from validator --chain-id cash -y
 
 echo "Querying verifiable credentials"
 cosmos-cashd query verifiablecredentialservice verifiable-credentials --output json | jq

--- a/scripts/seeds/04_user_seeds.sh
+++ b/scripts/seeds/04_user_seeds.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# user create accoutns
+# send users tokens
+# issuer sends tokens to users 
+# users send issuer tokens to each other and not kyc;d addresses 
+
+echo "Creating key for user user1"
+echo 'y' | cosmos-cashd keys add user1
+echo 'y' | cosmos-cashd keys add user2
+echo 'y' | cosmos-cashd keys add user3
+
+echo "Sending tokens to user 1 from validator"
+cosmos-cashd tx bank send $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user1 -a) 100000stake --from validator --chain-id cash -y
+cosmos-cashd tx bank send $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user2 -a) 100000stake --from validator --chain-id cash -y
+cosmos-cashd tx bank send $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user3 -a) 100000stake --from validator --chain-id cash -y
+
+echo "Creating decentralized identifier for users"
+cosmos-cashd tx identifier create-identifier --from user1 --chain-id cash -y
+cosmos-cashd tx identifier create-identifier --from user2 --chain-id cash -y
+cosmos-cashd tx identifier create-identifier --from user3 --chain-id cash -y
+
+echo "Creating verifiable credential for user :validator"
+cosmos-cashd tx verifiablecredentialservice create-verifiable-credential did:cash:$(cosmos-cashd keys show user1 -a) kyc-cred-1 --from validator --chain-id cash -y
+cosmos-cashd tx verifiablecredentialservice create-verifiable-credential did:cash:$(cosmos-cashd keys show user2 -a) kyc-cred-2 --from validator --chain-id cash -y
+cosmos-cashd tx verifiablecredentialservice create-verifiable-credential did:cash:$(cosmos-cashd keys show user3 -a) kyc-cred-3 --from validator --chain-id cash -y
+
+echo "Adding service to decentralized identifier for users"
+cosmos-cashd tx identifier add-service did:cash:$(cosmos-cashd keys show user1 -a) kyc-cred-1 KYCCredential cash:kyc-cred-1 --from user1 --chain-id cash -y
+cosmos-cashd tx identifier add-service did:cash:$(cosmos-cashd keys show user2 -a) kyc-cred-2 KYCCredential cash:kyc-cred-2 --from user2 --chain-id cash -y
+cosmos-cashd tx identifier add-service did:cash:$(cosmos-cashd keys show user3 -a) kyc-cred-3 KYCCredential cash:kyc-cred-3 --from user3 --chain-id cash -y
+
+cosmos-cashd query identifier identifiers --output json | jq
+cosmos-cashd query verifiablecredentialservice verifiable-credentials --output json | jq

--- a/x/verifiable-credential-service/client/cli/cli_test.go
+++ b/x/verifiable-credential-service/client/cli/cli_test.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 
 	"github.com/allinbits/cosmos-cash/x/verifiable-credential-service/client/cli"
 	"github.com/allinbits/cosmos-cash/x/verifiable-credential-service/types"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/allinbits/cosmos-cash/app"
 	"github.com/allinbits/cosmos-cash/app/params"
@@ -72,12 +75,18 @@ func (s *IntegrationTestSuite) TestGetCmdQueryVerifiableCredentials() {
 	val := s.network.Validators[0]
 
 	testCases := []struct {
-		name string
-		args []string
+		name      string
+		args      []string
+		expectErr bool
+		respType  proto.Message
+		expected  proto.Message
 	}{
 		{
-			"json output",
+			"PASS: querying verifiable credentials with a json output",
 			[]string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
+			false,
+			&types.QueryVerifiableCredentialsResponse{},
+			&types.QueryVerifiableCredentialsResponse{},
 		},
 	}
 
@@ -86,8 +95,126 @@ func (s *IntegrationTestSuite) TestGetCmdQueryVerifiableCredentials() {
 			cmd := cli.GetCmdQueryVerifiableCredentials()
 			clientCtx := val.ClientCtx
 
-			_, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			s.Require().NoError(err)
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Require().NoError(clientCtx.JSONMarshaler.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().Equal(tc.expected.String(), tc.respType.String())
+
+			}
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestGetCmdQueryVerifiableCredential() {
+	val := s.network.Validators[0]
+
+	testCases := []struct {
+		name      string
+		args      []string
+		expectErr bool
+		respType  proto.Message
+		expected  proto.Message
+	}{
+		{
+			"FAIL: querying verifiable credential with an id when none exists and json output",
+			[]string{"kyc-cred-1", fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
+			true,
+			&types.QueryVerifiableCredentialsResponse{},
+			&types.QueryVerifiableCredentialsResponse{},
+		},
+		{
+			"FAIL: querying verifiable credential without an id and json output",
+			[]string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
+			true,
+			&types.QueryVerifiableCredentialsResponse{},
+			&types.QueryVerifiableCredentialsResponse{},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			cmd := cli.GetCmdQueryVerifiableCredential()
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Require().NoError(clientCtx.JSONMarshaler.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().Equal(tc.expected.String(), tc.respType.String())
+
+			}
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestNewCreateVerifiableCredentialCmd() {
+	val := s.network.Validators[0]
+
+	testCases := []struct {
+		name         string
+		args         []string
+		expectErr    bool
+		respType     proto.Message
+		expectedCode uint32
+	}{
+		{
+			"PASS: creating a valid transaction in the verifiable credentials module",
+			[]string{
+				"did:cash:1111",
+				"test-cred-1",
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
+				fmt.Sprintf(
+					"--%s=%s",
+					flags.FlagFees,
+					sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String(),
+				),
+			},
+			false, &sdk.TxResponse{}, 0,
+		},
+		{
+			"FAIL: incorrect number of params passed into the create verifiable credentials client command",
+			[]string{
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
+				fmt.Sprintf(
+					"--%s=%s",
+					flags.FlagFees,
+					sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String(),
+				),
+			},
+			true, &sdk.TxResponse{}, 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			cmd := cli.NewCreateVerifiableCredentialCmd()
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+
+			// TODO: optimise this
+			errNet := s.network.WaitForNextBlock()
+			s.Require().NoError(errNet)
+			errNet = s.network.WaitForNextBlock()
+			s.Require().NoError(errNet)
+			if tc.expectErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Require().NoError(clientCtx.JSONMarshaler.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+
+				txResp := tc.respType.(*sdk.TxResponse)
+				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+			}
 		})
 	}
 }

--- a/x/verifiable-credential-service/client/cli/tx.go
+++ b/x/verifiable-credential-service/client/cli/tx.go
@@ -34,10 +34,10 @@ func GetTxCmd() *cobra.Command {
 // NewCreateVerifiableCredentialCmd defines the command to create a new verifiable credential.
 func NewCreateVerifiableCredentialCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create-verifiable-credential [id]",
+		Use:     "create-verifiable-credential [did_url] [cred-id]",
 		Short:   "create decentralized verifiable-credential",
 		Example: fmt.Sprintf("creates a verifiable credential for users"),
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -54,7 +54,7 @@ func NewCreateVerifiableCredentialCmd() *cobra.Command {
 			tm := time.Now()
 
 			vc := types.NewVerifiableCredential(
-				"new-verifiable-cred-3",
+				args[1],
 				[]string{"VerifiableCredential", "KYCCredential"},
 				accAddrBech32,
 				fmt.Sprintf("%s", tm),


### PR DESCRIPTION
### Description

Adding integration tests to the verifiable credentials module

### Issuer

closes: #28

### How to test

- `make test`

### Output

```sh
ok  	github.com/allinbits/cosmos-cash/x/verifiable-credential-service	0.062s	coverage: 52.6% of statements
ok  	github.com/allinbits/cosmos-cash/x/verifiable-credential-service/client/cli	23.275s	coverage: 59.4% of statements
ok  	github.com/allinbits/cosmos-cash/x/verifiable-credential-service/keeper	(cached)	coverage: 82.4% of statements
```