### PR TITLE
feat(events): adding identifier events

### DIFF
--- a/x/identifier/keeper/msg_server.go
+++ b/x/identifier/keeper/msg_server.go
@@ -41,6 +41,10 @@ func (k msgServer) CreateIdentifier(
 	identifier, _ := types.NewIdentifier(msg.Id, msg.Authentication)
 	k.Keeper.SetIdentifier(ctx, []byte(msg.Id), identifier)
 
+	ctx.EventManager().EmitEvent(
+		types.NewIdentifierCreatedEvent(msg.Id),
+	)
+
 	return &types.MsgCreateIdentifierResponse{}, nil
 }
 
@@ -72,6 +76,10 @@ func (k msgServer) AddAuthentication(
 	identifier.Authentication = append(identifier.Authentication, msg.Authentication)
 	k.Keeper.SetIdentifier(ctx, []byte(msg.Id), identifier)
 
+	ctx.EventManager().EmitEvent(
+		types.NewAuthenticationAddedEvent(msg.Id, msg.Authentication.Controller),
+	)
+
 	return &types.MsgAddAuthenticationResponse{}, nil
 }
 
@@ -100,6 +108,10 @@ func (k msgServer) AddService(
 
 	identifier.Services = append(identifier.Services, msg.ServiceData)
 	k.Keeper.SetIdentifier(ctx, []byte(msg.Id), identifier)
+
+	ctx.EventManager().EmitEvent(
+		types.NewServiceAddedEvent(msg.Id, msg.ServiceData.Id),
+	)
 
 	return &types.MsgAddServiceResponse{}, nil
 }
@@ -152,6 +164,10 @@ func (k msgServer) DeleteAuthentication(
 
 	k.Keeper.SetIdentifier(ctx, []byte(msg.Id), identifier)
 
+	ctx.EventManager().EmitEvent(
+		types.NewAuthenticationDeletedEvent(msg.Id, address.String()),
+	)
+
 	return &types.MsgDeleteAuthenticationResponse{}, nil
 }
 
@@ -199,6 +215,10 @@ func (k msgServer) DeleteService(
 	identifier.Services = services
 
 	k.Keeper.SetIdentifier(ctx, []byte(msg.Id), identifier)
+
+	ctx.EventManager().EmitEvent(
+		types.NewServiceDeletedEvent(msg.Id, msg.Id),
+	)
 
 	return &types.MsgDeleteServiceResponse{}, nil
 }

--- a/x/identifier/types/event.go
+++ b/x/identifier/types/event.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// identifier module event types
+const (
+	AttributeValueCategory = ModuleName
+
+	EventTypeIdentifierCreated     = "identifier_created"
+	EventTypeAuthenticationAdded   = "authentication_added"
+	EventTypeServiceAdded          = "service_added"
+	EventTypeAuthenticationDeleted = "authentication_deleted"
+	EventTypeServiceDeleted        = "service_deleted"
+
+	AttributeKeyOwner      = "owner"
+	AttributeKeyController = "authentication_controller"
+	AttributeKeyServiceID  = "service_id"
+)
+
+// NewIdentifierCreatedEvent constructs a new identifier_created sdk.Event
+func NewIdentifierCreatedEvent(owner string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeIdentifierCreated,
+		sdk.NewAttribute(AttributeKeyOwner, owner),
+	)
+}
+
+// NewAuthenticationAddedEvent constructs a new authentication_added sdk.Event
+func NewAuthenticationAddedEvent(owner string, controller string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeAuthenticationAdded,
+		sdk.NewAttribute(AttributeKeyOwner, owner),
+		sdk.NewAttribute(AttributeKeyController, controller),
+	)
+}
+
+// NewServiceAddedEvent constructs a new service_added sdk.Event
+func NewServiceAddedEvent(owner string, serviceID string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeServiceAdded,
+		sdk.NewAttribute(AttributeKeyOwner, owner),
+		sdk.NewAttribute(AttributeKeyServiceID, serviceID),
+	)
+}
+
+// NewAuthenticationDeletedEvent constructs a new authentication_deleted sdk.Event
+func NewAuthenticationDeletedEvent(owner string, controller string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeAuthenticationDeleted,
+		sdk.NewAttribute(AttributeKeyOwner, owner),
+		sdk.NewAttribute(AttributeKeyController, controller),
+	)
+}
+
+// NewServiceDeletedEvent constructs a new service_deleted sdk.Event
+func NewServiceDeletedEvent(owner string, serviceID string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeServiceDeleted,
+		sdk.NewAttribute(AttributeKeyOwner, owner),
+		sdk.NewAttribute(AttributeKeyServiceID, serviceID),
+	)
+}

--- a/x/issuer/keeper/msg_server.go
+++ b/x/issuer/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -72,6 +73,10 @@ func (k msgServer) CreateIssuer(
 		)
 	}
 
+	ctx.EventManager().EmitEvent(
+		types.NewIssuerCreatedEvent(msg.Owner, msg.Token, fmt.Sprint(circulatingSupply)),
+	)
+
 	return &types.MsgCreateIssuerResponse{}, nil
 }
 
@@ -120,6 +125,10 @@ func (k msgServer) BurnToken(
 			"cannot burn coins",
 		)
 	}
+
+	ctx.EventManager().EmitEvent(
+		types.NewTokenBurnedEvent(msg.Owner, issuer.Token, string(msg.Amount)),
+	)
 
 	return &types.MsgBurnTokenResponse{}, nil
 }
@@ -177,6 +186,10 @@ func (k msgServer) MintToken(
 			"failed sending tokens from module to issuer",
 		)
 	}
+
+	ctx.EventManager().EmitEvent(
+		types.NewTokenMintedEvent(msg.Owner, issuer.Token, string(msg.Amount)),
+	)
 
 	return &types.MsgMintTokenResponse{}, nil
 }

--- a/x/issuer/types/event.go
+++ b/x/issuer/types/event.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// issuer module event types
+const (
+	AttributeValueCategory = ModuleName
+
+	EventTypeIssuerCreated = "issuer_created"
+	EventTypeTokenMinted   = "issuer_minted_token"
+	EventTypeTokenBurned   = "issuer_burned_token"
+
+	AttributeKeyIssuer = "issuer"
+	AttributeKeyDenom  = "denom"
+	AttributeKeyAmount = "amount"
+)
+
+// NewIssuerCreatedEvent constructs a new issuer_created sdk.Event
+func NewIssuerCreatedEvent(issuer string, denom string, amount string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeIssuerCreated,
+		sdk.NewAttribute(AttributeKeyIssuer, issuer),
+		sdk.NewAttribute(AttributeKeyDenom, denom),
+		sdk.NewAttribute(AttributeKeyAmount, amount),
+	)
+}
+
+// NewTokenMintedvent constructs a new token_minted sdk.Event
+func NewTokenMintedEvent(issuer string, denom string, amount string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeTokenMinted,
+		sdk.NewAttribute(AttributeKeyIssuer, issuer),
+		sdk.NewAttribute(AttributeKeyDenom, denom),
+		sdk.NewAttribute(AttributeKeyAmount, amount),
+	)
+}
+
+// NewTokenBurnedEvent constructs a new token_burned sdk.Event
+func NewTokenBurnedEvent(issuer string, denom string, amount string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeTokenBurned,
+		sdk.NewAttribute(AttributeKeyIssuer, issuer),
+		sdk.NewAttribute(AttributeKeyDenom, denom),
+		sdk.NewAttribute(AttributeKeyAmount, amount),
+	)
+}

--- a/x/verifiable-credential-service/keeper/msg_server.go
+++ b/x/verifiable-credential-service/keeper/msg_server.go
@@ -44,5 +44,9 @@ func (k msgServer) CreateVerifiableCredential(
 		*msg.VerifiableCredential,
 	)
 
+	ctx.EventManager().EmitEvent(
+		types.NewCredentialCreatedEvent(msg.Owner, msg.VerifiableCredential.Id),
+	)
+
 	return &types.MsgCreateVerifiableCredentialResponse{}, nil
 }

--- a/x/verifiable-credential-service/types/event.go
+++ b/x/verifiable-credential-service/types/event.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// credential module event types
+const (
+	AttributeValueCategory = ModuleName
+
+	EventTypeCredentialCreated = "credential_created"
+
+	AttributeKeyOwner        = "owner"
+	AttributeKeyCredentialID = "credential_id"
+)
+
+// NewCredentialCreatedEvent constructs a new credential_created sdk.Event
+func NewCredentialCreatedEvent(owner string, credentialID string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeCredentialCreated,
+		sdk.NewAttribute(AttributeKeyOwner, owner),
+		sdk.NewAttribute(AttributeKeyCredentialID, credentialID),
+	)
+}


### PR DESCRIPTION
### Description

Adding the events to the project

### Task 

closes: #96 

### How to test

- `make start-dev`

### In a separate terminal run the following go code

```go
package main

import (
	"encoding/base64"
	"fmt"
	"github.com/sacOO7/gowebsocket"
	"github.com/tidwall/gjson"
	"time"
)

func main() {
	socket := gowebsocket.New("ws://localhost:26657/websocket")

	socket.OnTextMessage = func(message string, socket gowebsocket.Socket) {
		result := gjson.Get(message, `result.data.value.TxResult.result.events.#(type=="identifier_created").attributes`)
		for _, json := range result.Array() {
			key, _ := base64.StdEncoding.DecodeString(json.Get("key").String())
			value, _ := base64.StdEncoding.DecodeString(json.Get("value").String())
			fmt.Println("identifier_created")
			fmt.Println(string(key))
			fmt.Println(string(value))
			fmt.Println()
		}
		result = gjson.Get(message, `result.data.value.TxResult.result.events.#(type=="authentication_added").attributes`)
		for _, json := range result.Array() {
			key, _ := base64.StdEncoding.DecodeString(json.Get("key").String())
			value, _ := base64.StdEncoding.DecodeString(json.Get("value").String())
			fmt.Println("authentication_added")
			fmt.Println(string(key))
			fmt.Println(string(value))
			fmt.Println()
		}
		result = gjson.Get(message, `result.data.value.TxResult.result.events.#(type=="service_added").attributes`)
		for _, json := range result.Array() {
			fmt.Println("service_added")
			key, _ := base64.StdEncoding.DecodeString(json.Get("key").String())
			value, _ := base64.StdEncoding.DecodeString(json.Get("value").String())
			fmt.Println(string(key))
			fmt.Println(string(value))
			fmt.Println()
		}
		result = gjson.Get(message, `result.data.value.TxResult.result.events.#(type=="authentication_deleted").attributes`)
		for _, json := range result.Array() {
			fmt.Println("authentication_deleted")
			key, _ := base64.StdEncoding.DecodeString(json.Get("key").String())
			value, _ := base64.StdEncoding.DecodeString(json.Get("value").String())
			fmt.Println(string(key))
			fmt.Println(string(value))
			fmt.Println()
		}
		result = gjson.Get(message, `result.data.value.TxResult.result.events.#(type=="service_deleted").attributes`)
		for _, json := range result.Array() {
			fmt.Println("service_deleted")
			key, _ := base64.StdEncoding.DecodeString(json.Get("key").String())
			value, _ := base64.StdEncoding.DecodeString(json.Get("value").String())
			fmt.Println(string(key))
			fmt.Println(string(value))
			fmt.Println()
		}

	}

	socket.Connect()

	socket.SendText(`{ "jsonrpc": "2.0", "method": "subscribe", "params": ["tm.event='Tx'"], "id": 1 }`)

	for {
		time.Sleep(time.Second)
	}
}
```
- `make seed`


### Output 

```bash
identifier_created
owner
did:cash:cosmos1wht4dl3u7vm7lw5we5pnk9gc8j5qq76ulvx9ua

authentication_added
owner
did:cash:cosmos1wht4dl3u7vm7lw5we5pnk9gc8j5qq76ulvx9ua

authentication_added
authentication_controller
cosmos1tnhem30dx4wt22vzeqwmwew3ryjleum25kyfdn

service_added
owner
did:cash:cosmos1wht4dl3u7vm7lw5we5pnk9gc8j5qq76ulvx9ua

service_added
service_id
new-verifiable-cred-3

authentication_deleted
owner
did:cash:cosmos1wht4dl3u7vm7lw5we5pnk9gc8j5qq76ulvx9ua

authentication_deleted
authentication_controller
cosmos1tnhem30dx4wt22vzeqwmwew3ryjleum25kyfdn

service_deleted
owner
did:cash:cosmos1wht4dl3u7vm7lw5we5pnk9gc8j5qq76ulvx9ua

service_deleted
service_id
did:cash:cosmos1wht4dl3u7vm7lw5we5pnk9gc8j5qq76ulvx9ua
```