### PR TITLE
fix(issuer): adding check so issuers cannot create the same token

### DIFF
--- a/x/issuer/keeper/msg_server.go
+++ b/x/issuer/keeper/msg_server.go
@@ -37,16 +37,24 @@ func (k msgServer) CreateIssuer(
 		)
 	}
 
+	_, found = k.Keeper.GetIssuerByToken(ctx, []byte(msg.Token))
+	if found {
+		return nil, sdkerrors.Wrapf(
+			types.ErrIssuerFound,
+			"token denom already exists",
+		)
+	}
+
 	// TODO: should the did URI be the issuer address
-	identifier := types.Issuer{
+	issuer := types.Issuer{
 		Token:   msg.Token,
 		Fee:     msg.Fee,
 		Address: msg.Owner,
 	}
 
-	k.Keeper.SetIssuer(ctx, identifier)
+	k.Keeper.SetIssuer(ctx, issuer)
 
-	// TODO: this needs to be refactored
+	// TODO: remove the next 24 lines in favor of minting tokens using the mint command
 	circulatingSupply := 1000000000000
 
 	issuerToken := sdk.NewCoins(sdk.NewInt64Coin(msg.Token, int64(circulatingSupply)))


### PR DESCRIPTION
### Description

Adding check to create issuer command to check for denom, this makes sure issuers cannot create the same denom

### Issue

closes: #100 

### How to test

- `make start-dev`
- `make seed`

|| 

- `make test`