### PR TITLE
feat(did): add logging to the msg_server

### DIFF
--- a/scripts/seeds/01_identifier_seeds.sh
+++ b/scripts/seeds/01_identifier_seeds.sh
@@ -16,10 +16,22 @@ echo "Adding service to decentralized did for user: validator"
 cosmos-cashd tx did add-service vasp new-verifiable-cred-3 KYCCredential cosmos-cash:new-verifiable-cred-3 --from validator --chain-id cash -y
 
 vmID=$(cosmos-cashd query did dids --output json | jq '.didDocuments[0].verificationMethods[1].id')
-echo $vmID
+vmID=${vmID:10:-1}
+
+echo "Adding a verification relationship from decentralized did for user: validator"
+cosmos-cashd tx did add-verification-relationship vasp $vmID assertionMethod --from validator --chain-id cash -y
+
+echo "Querying dids"
+cosmos-cashd query did dids --output json | jq
 
 echo "Revoking verification method from decentralized did for user: validator"
-#cosmos-cashd tx did revoke-verification-method vasp $(echo $vmID)--from validator --chain-id cash -y
+cosmos-cashd tx did revoke-verification-method vasp $vmID --from validator --chain-id cash -y
+
+echo "Creating key for user didcontroller"
+echo 'y' | cosmos-cashd keys add didcontroller
+
+echo "Adding a controller to a did document for user: validator"
+cosmos-cashd tx did update-did-document vasp $(cosmos-cashd keys show didcontroller -a) --from validator --chain-id cash -y
 
 echo "Querying dids"
 cosmos-cashd query did dids --output json | jq

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -123,7 +123,7 @@ func NewAddVerificationCmd() *cobra.Command {
 					vmID,
 					pubKey.Type(),
 					did,
-					types.BlockchainAccountID(signer.String()),
+					types.BlockchainAccountID(pubKey.Address().String()), // FIXME: this needs to be the address of args[1]
 				),
 				[]string{types.RelationshipAuthentication},
 				nil,

--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -56,7 +56,10 @@ func (k msgServer) CreateDidDocument(
 }
 
 // UpdateDidDocument update an existing DID document
-func (k msgServer) UpdateDidDocument(goCtx context.Context, msg *types.MsgUpdateDidDocument) (*types.MsgUpdateDidDocumentResponse, error) {
+func (k msgServer) UpdateDidDocument(
+	goCtx context.Context,
+	msg *types.MsgUpdateDidDocument,
+) (*types.MsgUpdateDidDocumentResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// get the did document
@@ -254,7 +257,10 @@ func (k msgServer) DeleteService(
 }
 
 // SetVerificationRelationships set the verification relationships for an existing DID document
-func (k msgServer) SetVerificationRelationships(goCtx context.Context, msg *types.MsgSetVerificationRelationships) (*types.MsgSetVerificationRelationshipsResponse, error) {
+func (k msgServer) SetVerificationRelationships(
+	goCtx context.Context,
+	msg *types.MsgSetVerificationRelationships,
+) (*types.MsgSetVerificationRelationshipsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// retrieve the did document

--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -45,6 +45,9 @@ func (k msgServer) CreateDidDocument(
 
 	// persist the did document
 	k.Keeper.SetDidDocument(ctx, []byte(msg.Id), did)
+
+	k.Logger(ctx).Info("Created a DidDocument for", "did", msg.Id, "controller", msg.Signer)
+
 	// emit the event
 	ctx.EventManager().EmitEvent(
 		types.NewDidDocumentCreatedEvent(msg.Id),
@@ -77,6 +80,8 @@ func (k msgServer) UpdateDidDocument(goCtx context.Context, msg *types.MsgUpdate
 	}
 	// write the did
 	k.Keeper.SetDidDocument(ctx, []byte(msg.Id), didDoc)
+
+	k.Logger(ctx).Info("Updated a DidDocument for", "did", msg.Id, "controller", msg.Signer)
 
 	// NOTE: events are expected to change during client development
 	ctx.EventManager().EmitEvent(
@@ -114,6 +119,8 @@ func (k msgServer) AddVerification(
 
 	// write the did
 	k.Keeper.SetDidDocument(ctx, []byte(msg.Id), didDoc)
+
+	k.Logger(ctx).Info("Added a new verification method for", "did", msg.Id, "controller", msg.Signer)
 
 	// NOTE: events are expected to change during client development
 	ctx.EventManager().EmitEvent(
@@ -159,6 +166,8 @@ func (k msgServer) AddService(
 	}
 	// write to storage
 	k.Keeper.SetDidDocument(ctx, []byte(msg.Id), didDoc)
+
+	k.Logger(ctx).Info("Added a new service for", "did", msg.Id, "controller", msg.Signer)
 	// NOTE: events are expected to change during client development
 	ctx.EventManager().EmitEvent(
 		types.NewServiceAddedEvent(msg.Id, msg.ServiceData.Id),
@@ -193,6 +202,8 @@ func (k msgServer) RevokeVerification(
 
 	// persist to storage
 	k.Keeper.SetDidDocument(ctx, []byte(msg.Id), didDoc)
+
+	k.Logger(ctx).Info("Revoked verification method from did document for", "did", msg.Id, "controller", msg.Signer)
 
 	// emit event
 	ctx.EventManager().EmitEvent(
@@ -232,6 +243,8 @@ func (k msgServer) DeleteService(
 	// persist the did document
 	k.Keeper.SetDidDocument(ctx, []byte(msg.Id), didDoc)
 
+	k.Logger(ctx).Info("Removed service from did document for", "did", msg.Id, "controller", msg.Signer)
+
 	// NOTE: events are expected to change during client development
 	ctx.EventManager().EmitEvent(
 		types.NewServiceDeletedEvent(msg.Id, msg.ServiceId),
@@ -266,6 +279,8 @@ func (k msgServer) SetVerificationRelationships(goCtx context.Context, msg *type
 
 	// persist the did document
 	k.Keeper.SetDidDocument(ctx, []byte(msg.Id), didDoc)
+
+	k.Logger(ctx).Info("Set verification relationship from did document for", "did", msg.Id, "controller", msg.Signer)
 
 	// NOTE: events are expected to change during client development
 	ctx.EventManager().EmitEvent(

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -60,6 +60,10 @@ func DID(didMethodSpecificDidDocument string) string {
 	return fmt.Sprint(DidPrefix, didMethodSpecificDidDocument)
 }
 
+func DIDKey(didMethodSpecificDidDocument string) string {
+	return fmt.Sprint(DidKeyPrefix, didMethodSpecificDidDocument)
+}
+
 // BlockchainAccountID return the account of the user with the chain id postfixed
 // https://w3c.github.io/did-spec-registries/#blockchainAccountId
 func BlockchainAccountID(account string) string {

--- a/x/did/types/keys.go
+++ b/x/did/types/keys.go
@@ -21,6 +21,9 @@ const (
 	// DidPrefix defines the did prefix for this chain
 	DidPrefix = "did:cash:"
 
+	// DidKeyPrefix defines the did key prefix
+	DidKeyPrefix = "did:key:"
+
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_capability"
 )


### PR DESCRIPTION
### Description

Adding logging to the msg_server

### Issue

closes: #127 

### How to test

- `make start-dev`
- `make seed`

### What it should look like

```sh
INF Created a DidDocument for controller=cosmos1ps2x9lnnkvf46tl7u9y4aff92kpsxlw5q968yk did=did:cash:vasp module=x/did
```
