### PR TITLE
chore: comment formatting in cli transaction

### DIFF
--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -314,7 +314,7 @@ func NewUpdateDidDocumentCmd() *cobra.Command {
 	return cmd
 }
 
-// NewUpdateDidDocumentCmd adds a controller to a did document
+// NewAddVerificationRelationshipCmd adds a verification relationship to a verification method
 func NewAddVerificationRelationshipCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add-verification-relationship [id] [method-id] [relationship]",


### PR DESCRIPTION
### Description

Issue #143 outlines checks for comments in the CI, these checks have already been implemented, other comments defined in [conventional comments](https://conventionalcomments.org/) are for reviews and outside the scope of CI linting checks. But as a team, we should follow conventional comments to improve communication! :smile: 

### Issue

closes: #143 

### How to test

- `golangci-lint help linters`

See linter presets:
```
Linter presets:
...
comment: godot, godox, misspell
...
```

- [godot](https://github.com/tetafro/godot) and [godox](https://github.com/matoous/godox) are not needed for the moment

Review checks in [golangci-lint file](https://github.com/allinbits/cosmos-cash/blob/main/.golangci.yaml#L21-L22):

```yaml
linters:
  disable-all: true
  presets:
    - bugs
    - unused
    - import
    # - error to be enabled next
  enable:
    - misspell
    - revive
```


