### PR TITLE
fix(verificationMethod): update resolution of blockchainAccountID to …

### DIFF
--- a/scripts/seeds/01_identifier_seeds.sh
+++ b/scripts/seeds/01_identifier_seeds.sh
@@ -15,8 +15,8 @@ cosmos-cashd query did dids --output json | jq
 echo "Adding service to decentralized did for user: validator"
 cosmos-cashd tx did add-service vasp new-verifiable-cred-3 KYCCredential cosmos-cash:new-verifiable-cred-3 --from validator --chain-id cash -y
 
-vmID=$(cosmos-cashd query did dids --output json | jq '.didDocuments[0].verificationMethods[1].id')
-vmID=${vmID:10:-1}
+vmID=$(cosmos-cashd query did dids --output json | jq '.didDocuments[0].verificationMethod[1].id')
+vmID=${vmID:17:-1}
 
 echo "Adding a verification relationship from decentralized did for user: validator"
 cosmos-cashd tx did add-verification-relationship vasp $vmID assertionMethod --from validator --chain-id cash -y

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -70,7 +69,7 @@ func NewCreateDidDocumentCmd() *cobra.Command {
 				types.NewVerificationMethod(
 					vmID,
 					did,
-					hex.EncodeToString(pubKey.Bytes()),
+					pubKey,
 					types.DIDVerificationMaterialPublicKeyHex,
 				),
 				[]string{types.Authentication},
@@ -125,8 +124,8 @@ func NewAddVerificationCmd() *cobra.Command {
 				types.NewVerificationMethod(
 					vmID,
 					did,
-					hex.EncodeToString(pubKey.Bytes()),
-					types.DIDVerificationMaterialPublicKeyHex,
+					pubKey,
+					types.DIDVerificationMaterialBlockchainAccountID,
 				),
 				[]string{types.Authentication},
 				nil,

--- a/x/did/resolver/resolver.go
+++ b/x/did/resolver/resolver.go
@@ -66,7 +66,8 @@ func ResolveAccountDID(did string) (didDoc types.DidDocument, didMeta types.DidM
 			types.NewVerificationMethod(
 				fmt.Sprint(did, "#", account),
 				did,
-				account,
+				// FIXME: this needs to be updated as the NewVerificationMethod function expects a publicKey
+				nil,
 				types.DIDVerificationMaterialBlockchainAccountID,
 			),
 			[]string{

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -627,17 +628,21 @@ func NewVerification(
 }
 
 // NewVerificationMethod build a new verification method
-func NewVerificationMethod(id, controller, key string, vmt VerificationMaterialType) VerificationMethod {
+func NewVerificationMethod(id, controller string, pubKey cryptotypes.PubKey, vmt VerificationMaterialType) VerificationMethod {
 	vm := VerificationMethod{
 		Id:         id,
 		Controller: controller,
 	}
 	switch vmt {
 	case DIDVerificationMaterialPublicKeyHex:
-		vm.VerificationMaterial = &VerificationMethod_PublicKeyHex{key}
+		vm.VerificationMaterial = &VerificationMethod_PublicKeyHex{
+			hex.EncodeToString(pubKey.Bytes()),
+		}
 		vm.Type = DIDVerificationMethodTypeSecp256k1_2020
 	case DIDVerificationMaterialBlockchainAccountID:
-		vm.VerificationMaterial = &VerificationMethod_BlockchainAccountID{key}
+		vm.VerificationMaterial = &VerificationMethod_BlockchainAccountID{
+			sdk.MustBech32ifyAddressBytes(sdk.GetConfig().GetBech32AccountAddrPrefix(), pubKey.Address().Bytes()),
+		}
 		vm.Type = DIDVerificationMethodTypeCosmosAddress
 	}
 	return vm


### PR DESCRIPTION
### Description

Suggestions to update the `NewVerificationMethod` function to handle blockchainAccountId correctly

### Problem

The blockchain Account Id was being resolved incorrectly when adding a new verification method

#### What it looked like
```json
...
      "verificationMethod": [
        {
          "controller": "did:cosmos:cash:vasp",
          "id": "did:cosmos:cash:vasp#cosmos1rqp5ng9hukxphfckyev5fyvpa9gypcj5v9vgcd",
          "publicKeyHex": "0367d042431c9f08e7d742f20d89612444a6872cc158c19645f56a588371838a83",
          "type": "EcdsaSecp256k1RecoveryMethod2020"
        },
        {
          "blockchainAccountId": "035cc99168e267d11a5859578b87e68518125b63e8ba682ad8cb74c2efd7529da4",
          "controller": "did:cosmos:cash:vasp",
          "id": "did:cosmos:cash:vasp#cosmos182dqcwxkqng9ea4ffa6qythdxuet0n7scsrk69",
          "type": "CosmosAccountAddress"
        }
      ],

...
```

#### What it should look like
```json
...
      "verificationMethod": [
        {
          "controller": "did:cosmos:cash:vasp",
          "id": "did:cosmos:cash:vasp#cosmos12z7xttlp3ku7304vjh9r89v3nyezwurmen3jgv",
          "publicKeyHex": "02537d685a65bbd01a218c790f46241ff796d070139410fc453374085643f410fa",
          "type": "EcdsaSecp256k1RecoveryMethod2020"
        },
        {
          "blockchainAccountId": "cosmos1zt7merh06qu8fegr5dyw4tzfr9g5rtwexvy2ul",
          "controller": "did:cosmos:cash:vasp",
          "id": "did:cosmos:cash:vasp#cosmos1zt7merh06qu8fegr5dyw4tzfr9g5rtwexvy2ul",
          "type": "CosmosAccountAddress"
        }
      ],

...
```

### How to test

- `make start-dev`
- `make seed`

### TBD

- [ ] Fix the resolution of the `did:cosmos:key` did document => I'll do that shortly :smile: => outlined as `FIXME` in code