### PR TITLE
feat: polishing credential issuance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ seed:
 	./scripts/seeds/01_identifier_seeds.sh
 	./scripts/seeds/02_verifiable_credentials_seeds.sh
 	./scripts/seeds/03_issuer_seeds.sh
+	./scripts/seeds/04_user_seeds.sh
 
 ###############################################################################
 ###                                CI / CD                                  ###

--- a/scripts/seeds/01_identifier_seeds.sh
+++ b/scripts/seeds/01_identifier_seeds.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 
 echo "Create a DID doc for the regulator (by the regulator account)"
-cosmos-cashd tx did create-did regulator --from regulator --chain-id cash -y 
+cosmos-cashd tx did create-did regulator \
+ --from regulator \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 cosmos-cashd query did did did:cosmos:net:cash:regulator --output json | jq
 
 echo "Create a DID doc for the EMTi (by the validator)"
-cosmos-cashd tx did create-did emti --from validator --chain-id cash -y 
+cosmos-cashd tx did create-did emti --from validator \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 cosmos-cashd query did did did:cosmos:net:cash:emti --output json | jq
 
 echo "Add the EMTi account verification method to the the EMTi DID doc (by the validator account)"
-cosmos-cashd tx did add-verification-method emti $(cosmos-cashd keys show emti -p) --from validator --chain-id cash -y
+cosmos-cashd tx did add-verification-method emti $(cosmos-cashd keys show emti -p) \
+ --from validator \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 cosmos-cashd query did did did:cosmos:net:cash:emti --output json | jq
 
 echo "Querying dids"
@@ -23,39 +25,39 @@ cosmos-cashd query did dids --output json | jq
 
 echo "Add a service to the EMTi DID doc (by the EMTi account)"
 cosmos-cashd tx did add-service emti emti-agent DIDComm "https://agents.cosmos-cash.app.beta.starport.cloud/emti" \
---from emti --chain-id cash -y
+--from emti \
+--chain-id cash -y --broadcast-mode block
 
-sleep 5
 cosmos-cashd query did did did:cosmos:net:cash:emti --output json | jq
 
 echo "Adding a verification relationship from decentralized did for validator"
 cosmos-cashd tx did set-verification-relationship emti $(cosmos-cashd keys show validator -a) --relationship assertionMethod --relationship capabilityInvocation \
---from emti --chain-id cash -y
+--from emti \
+--chain-id cash -y --broadcast-mode block
 
-sleep 5
 cosmos-cashd query did did did:cosmos:net:cash:emti --output json | jq
 
 echo "Revoking verification method from decentralized did for user: validator"
 cosmos-cashd tx did revoke-verification-method emti $(cosmos-cashd keys show validator -a) \
---from emti --chain-id cash -y
+--from emti \
+--chain-id cash -y --broadcast-mode block
 
-sleep 5
 cosmos-cashd query did did did:cosmos:net:cash:emti --output json | jq
 
 echo "Adding Alice as controller of the EMTi did (by EMTi user)"
 cosmos-cashd tx did update-did-document emti $(cosmos-cashd keys show alice -a) \
---from emti --chain-id cash -y
+--from emti \
+--chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying dids"
 cosmos-cashd query did dids --output json | jq
 
 echo "Deleting service from EMTi did document (by EMTi user)"
 cosmos-cashd tx did delete-service emti emti-agent \
---from emti --chain-id cash -y
+--from emti \
+--chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying dids"
 cosmos-cashd query did dids --output json | jq

--- a/scripts/seeds/02_verifiable_credentials_seeds.sh
+++ b/scripts/seeds/02_verifiable_credentials_seeds.sh
@@ -1,64 +1,63 @@
 #!/bin/bash
 
 echo "Create Regulator VC to activate the Regulator did"
-cosmos-cashd tx regulator activate-regulator-credential TheAuthority EU --did did:cosmos:net:cash:regulator \
---from regulator --chain-id cash -y
+cosmos-cashd tx regulator activate-regulator-credential \
+TheAuthority EU \
+--subject-did did:cosmos:net:cash:regulator \
+--from regulator --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Create Registration VC for EMTi did"
 cosmos-cashd tx regulator issue-registration-credential \
-did:cosmos:net:cash:emti-registration-credential did:cosmos:net:cash:regulator did:cosmos:net:cash:emti \
+did:cosmos:net:cash:regulator did:cosmos:net:cash:emti \
 EU "First Galactic Bank" "FGB" \
---from regulator --chain-id cash -y
+--credential-id did:cosmos:net:cash:emti-registration-credential \
+--from regulator --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Create License VC for EMTi did (sEUR)"
 cosmos-cashd tx regulator issue-license-credential \
-did:cosmos:net:cash:emti-eurolicense-credential did:cosmos:net:cash:regulator did:cosmos:net:cash:emti \
+did:cosmos:net:cash:regulator did:cosmos:net:cash:emti \
 MICAEMI IRL "Another Financial Services Body (AFFB)" sEUR 10000 \
---from regulator --chain-id cash -y
+--credential-id did:cosmos:net:cash:emti-eurolicense-credential \
+--from regulator --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Create License VC for EMTi did (sUSD)"
 cosmos-cashd tx regulator issue-license-credential \
-did:cosmos:net:cash:emti-dollarlicense-credential did:cosmos:net:cash:regulator did:cosmos:net:cash:emti \
+did:cosmos:net:cash:regulator did:cosmos:net:cash:emti \
 MICAEMI PG "Yet Another Financial Services Body (YAFFB)" sUSD 10000 \
---from regulator --chain-id cash -y
+--credential-id did:cosmos:net:cash:emti-dollarlicense-credential \
+--from regulator --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Revoke the (sUSD) license"
 cosmos-cashd tx verifiablecredential revoke-credential \
 did:cosmos:net:cash:emti-dollarlicense-credential \
---from regulator --chain-id cash -y
+--from regulator --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Creating User VC for user alice"
 cosmos-cashd tx issuer issue-user-credential \
-did:cosmos:key:$(cosmos-cashd keys show alice -a) did:cosmos:cred:emti-user-alice did:cosmos:net:cash:emti zkp_secret 1000 1000 1000  \
---from emti --chain-id cash -y
+did:cosmos:net:cash:emti did:cosmos:key:$(cosmos-cashd keys show alice -a) zkp_secret 1000 1000 1000 \
+--credential-id did:cosmos:cred:emti-user-alice \
+--from emti --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Creating User VC for user bob"
 cosmos-cashd tx issuer issue-user-credential \
-did:cosmos:key:$(cosmos-cashd keys show bob -a) did:cosmos:cred:emti-user-bob did:cosmos:net:cash:emti zkp_secret 1000 1000 1000  \
---from emti --chain-id cash -y
+did:cosmos:net:cash:emti did:cosmos:key:$(cosmos-cashd keys show bob -a) zkp_secret 1000 1000 1000  \
+--credential-id did:cosmos:cred:emti-user-bob \
+--from emti --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying verifiable credentials"
 cosmos-cashd query verifiablecredential verifiable-credentials --output json | jq
 
 echo "Revoke Bob's user credential"
 cosmos-cashd tx verifiablecredential revoke-credential did:cosmos:cred:emti-user-bob \
---from emti --chain-id cash -y
+--from emti --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying verifiable credentials"
 cosmos-cashd query verifiablecredential verifiable-credentials --output json | jq

--- a/scripts/seeds/03_issuer_seeds.sh
+++ b/scripts/seeds/03_issuer_seeds.sh
@@ -1,41 +1,51 @@
 #!/bin/bash
 
 echo "Creating issuer for user: emti"
-cosmos-cashd tx issuer create-issuer did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential sEUR 100 --from emti --chain-id cash -y
+cosmos-cashd tx issuer create-issuer \
+ did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential sEUR 100 \
+ --from emti \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying all issuers"
 cosmos-cashd query issuer issuers --output json | jq
 
 echo "Mint tokens for issuer: emti"
-cosmos-cashd tx issuer mint-token did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential 9999sEUR --from emti --chain-id cash -y
+cosmos-cashd tx issuer mint-token \
+ did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential 9999sEUR \
+ --from emti \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Check that the tokens have been minted"
 cosmos-cashd query bank total --output json | jq
 
 echo "Burn tokens for issuer: emti"
-cosmos-cashd tx issuer burn-token did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential 1000sEUR --from emti --chain-id cash -y
+cosmos-cashd tx issuer burn-token \
+ did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential 1000sEUR \
+ --from emti \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Check that the tokens have been burned"
 cosmos-cashd query bank total --output json | jq
 
 echo "Pause tokens for issuer: emti"
-cosmos-cashd tx issuer pause-token did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential --from emti --chain-id cash -y
+cosmos-cashd tx issuer pause-token \
+ did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential \
+ --from emti \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying all issuers"
 cosmos-cashd query issuer issuers --output json | jq
 
 echo "Unpause tokens for issuer: emti"
-cosmos-cashd tx issuer pause-token did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential --from emti --chain-id cash -y
+cosmos-cashd tx issuer pause-token \
+ did:cosmos:net:cash:emti did:cosmos:net:cash:emti-eurolicense-credential \
+ --from emti \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying all issuers"
 cosmos-cashd query issuer issuers --output json | jq

--- a/scripts/seeds/04_user_seeds.sh
+++ b/scripts/seeds/04_user_seeds.sh
@@ -5,71 +5,88 @@ echo 'y' | cosmos-cashd keys add user1
 echo 'y' | cosmos-cashd keys add user2
 
 echo "Sending tokens to user 1 from validator"
-cosmos-cashd tx bank send $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user1 -a) 100000stake --from validator --chain-id cash -y
+cosmos-cashd tx bank send \
+ $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user1 -a) 100000stake \
+ --from validator \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
+echo "Sending tokens to user 2 from validator"
+cosmos-cashd tx bank send \
+ $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user2 -a) 100000stake \
+ --from validator \
+ --chain-id cash -y --broadcast-mode block
 
-cosmos-cashd tx bank send $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user2 -a) 100000stake --from validator --chain-id cash -y
 
-sleep 5
+echo "Creating decentralized did for user1"
+cosmos-cashd tx did create-did user1 \
+ --from user1 \
+ --chain-id cash -y --broadcast-mode block
 
-echo "Creating decentralized did for users"
-cosmos-cashd tx did create-did user1 --from user1 --chain-id cash -y
+echo "Creating decentralized did for user2"
+cosmos-cashd tx did create-did user2 \
+ --from user2 \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
-
-cosmos-cashd tx did create-did user2 --from user2 --chain-id cash -y
-
-sleep 5
 
 echo "Creating verifiable credential for user :user1"
 cosmos-cashd tx issuer issue-user-credential \
-	did:cosmos:net:cash:user1-cred did:cosmos:net:cash:user1 did:cosmos:net:cash:emti secret 1000 1000 1000  \
-	--from emti --chain-id cash -y
+	did:cosmos:net:cash:emti did:cosmos:net:cash:user1 secret 1000 1000 1000  \
+	--credential-id did:cosmos:net:cash:user1-pokyc \
+	--from emti \
+	--chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Creating verifiable credential for user :user2"
 cosmos-cashd tx issuer issue-user-credential \
-	did:cosmos:net:cash:user2-cred did:cosmos:net:cash:user2 did:cosmos:net:cash:emti secret 1000 1000 1000  \
-	--from validator --chain-id cash -y
+	did:cosmos:net:cash:emti did:cosmos:net:cash:user2 secret 1000 1000 1000  \
+	--credential-id did:cosmos:net:cash:user2-pokyc \
+	--from emti \
+	--chain-id cash -y --broadcast-mode block
 
-sleep 5
 
-echo "Creating verifiable credential for user :validator"
+echo "Self-issuing proof of kyc to itself: emti"
 cosmos-cashd tx issuer issue-user-credential \
-	did:cosmos:net:cash:emti did:cosmos:net:cash:user3 did:cosmos:net:cash:emti secret 1000 1000 1000  \
-	--from validator --chain-id cash -y
+	did:cosmos:net:cash:emti did:cosmos:net:cash:emti secret 1000 1000 1000  \
+	--credential-id did:cosmos:net:cash:emti-pokyc \
+	--from emti \
+	--chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying all data"
 cosmos-cashd query did dids --output json | jq
 cosmos-cashd query verifiablecredential verifiable-credentials --output json | jq
 
 echo "Sending issuer tokens to users from emti"
-cosmos-cashd tx bank send $(cosmos-cashd keys show emti -a) $(cosmos-cashd keys show user1 -a) 10sEUR --from emti --chain-id cash -y
+cosmos-cashd tx bank send \
+ $(cosmos-cashd keys show emti -a) $(cosmos-cashd keys show user1 -a) 10sEUR \
+ --from emti \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Sending issuer tokens to users from emti"
-cosmos-cashd tx bank send $(cosmos-cashd keys show emti -a) $(cosmos-cashd keys show user2 -a) 10sEUR --from emti --chain-id cash -y
+cosmos-cashd tx bank send \
+ $(cosmos-cashd keys show emti -a) $(cosmos-cashd keys show user2 -a) 10sEUR \
+ --from emti \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying balances for users"
 cosmos-cashd query bank balances $(cosmos-cashd keys show user1 -a) --output json | jq
 cosmos-cashd query bank balances $(cosmos-cashd keys show user2 -a) --output json | jq
 
 echo "Pause tokens for issuer: validator"
-cosmos-cashd tx issuer pause-token did:cosmos:net:cash:vasp did:cosmos:net:cash:eurolicense-credential --from validator --chain-id cash -y
+cosmos-cashd tx issuer pause-token \
+ did:cosmos:net:cash:emti did:cosmos:net:cash:eurolicense-credential \
+ --from regulator \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Sending paused issuer tokens to user from validator: should fail"
-cosmos-cashd tx bank send $(cosmos-cashd keys show validator -a) $(cosmos-cashd keys show user2 -a) 10sEUR --from validator --chain-id cash -y
+cosmos-cashd tx bank send \
+ $(cosmos-cashd keys show user1 -a) $(cosmos-cashd keys show user2 -a) 10sEUR \
+ --from user1 \
+ --chain-id cash -y --broadcast-mode block
 
-sleep 5
 
 echo "Querying balances for user2 should be 10sEUR"
 cosmos-cashd query bank balances $(cosmos-cashd keys show user2 -a) --output json | jq

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -217,10 +217,13 @@ func NewAddServiceCmd() *cobra.Command {
 
 func NewRevokeVerificationCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "revoke-verification-method [id] [verificationMethodAddress]",
-		Short:   "revoke a verification method from a decentralized did (did) document",
-		Example: "revoke a verification method for a did document",
-		Args:    cobra.ExactArgs(2),
+		Use:   "revoke-verification-method [did_id] [verification_method_id_fragment]",
+		Short: "revoke a verification method from a decentralized did (did) document",
+		Example: `cosmos-cashd tx did revoke-verification-method 575d062c-d110-42a9-9c04-cb1ff8c01f06 \
+ Z46DAL1MrJlVW_WmJ19WY8AeIpGeFOWl49Qwhvsnn2M \
+ --from alice \
+ --node https://rpc.cosmos-cash.app.beta.starport.cloud:443 --chain-id cosmoscash-testnet`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -341,9 +344,9 @@ func NewSetVerificationRelationshipCmd() *cobra.Command {
 	var unsafe bool
 
 	cmd := &cobra.Command{
-		Use:     "set-verification-relationship [id] [address] --relationship NAME [--relationship NAME ...]",
+		Use:     "set-verification-relationship [did_id] [verification_method_id_fragment] --relationship NAME [--relationship NAME ...]",
 		Short:   "sets one or more verification relationships to a key on a decentralized identifier (did) document.",
-		Example: "set-verification-relationship vasp vasp#6f1e0700-6c86-41b6-9e05-ae3cf839cdd0 --relationship capabilityInvocation",
+		Example: "set-verification-relationship vasp 6f1e0700-6c86-41b6-9e05-ae3cf839cdd0 --relationship capabilityInvocation",
 		Args:    cobra.ExactArgs(2),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -366,10 +369,6 @@ func NewSetVerificationRelationshipCmd() *cobra.Command {
 				relationships,
 				signer.String(),
 			)
-
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			// make sure that the authentication relationship is preserved
 			if !unsafe {

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -73,6 +73,7 @@ func TestIsValidDIDURL(t *testing.T) {
 		{"did:cash:cosmos1uam3kpjdx3wksx46lzq6y628wwyzv0guuren75", true},
 		{"did:cash:cosmos1uam3kpjdx3wksx46lzq6y628wwyzv0guuren75#key-1", true},
 		{"did:cash:cosmos1uam3kpjdx3wksx46lzq6y628wwyzv0guuren75?key=1", true},
+		{"did:cosmos:net:cosmoscash-testnet:575d062c-d110-42a9-9c04-cb1ff8c01f06#Z46DAL1MrJlVW_WmJ19WY8AeIpGeFOWl49Qwhvsnn2M", true},
 		{"did:subject", false},
 		{"DID:cash:subject", false},
 		{"d1d:cash:subject", false},


### PR DESCRIPTION
polish credential issuance cli parameters:

- auto-generate credentials id (overridden with `--credential-id` option)
- allow to set both issuer and subject did 
- improve parameter names for clarity
- update seed files  

to test:

```
make start-dev
make seed
```

